### PR TITLE
Make wallet-api available

### DIFF
--- a/wallet/api.cpp
+++ b/wallet/api.cpp
@@ -115,6 +115,7 @@ namespace beam
         if (params["address"].empty())
             throwInvalidJsonRpc(id);
 
+       
         Send send;
         //send.session = params["session"];
         send.value = params["value"];
@@ -492,7 +493,15 @@ namespace beam
 
         try
         {
-            json msg = json::parse(data, data + size);
+            std::string str_data(data);
+            json json_data = json::parse(data);
+            if(!json_data.is_object())
+            {
+               return false;
+            }
+
+            //std::string data_test = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"create_address\",\"params\":{\"lifetime\":24,\"metadata\":\"string encoded JSON metadata\"}}";
+            json msg = json::parse(str_data);//json::parse(data, data + size);
 
             if (msg["jsonrpc"] != "2.0") throwInvalidJsonRpc();
             if (msg["id"] <= 0) throwInvalidJsonRpc();

--- a/wallet/api_cli.cpp
+++ b/wallet/api_cli.cpp
@@ -529,7 +529,23 @@ namespace beam
 
             bool on_raw_message(void* data, size_t size)
             {
-                LOG_INFO() << "got " << std::string((char*)data, size);
+                const char* const_data = static_cast<const char*>(data);
+                std::string str_data(const_data);
+              //  std::string((char*)data,size);
+                LOG_INFO() << "got " << str_data;
+                try
+                {
+
+                    json json_data = json::parse(str_data);
+                    if(!json_data.is_object())
+                    {
+                        return true;
+                    }
+                }
+                catch(...)
+                {
+                    return true;
+                }
 
                 return _api.parse(static_cast<const char*>(data), size);
             }
@@ -549,6 +565,7 @@ namespace beam
                     _server.closeConnection(_stream->peer_address().u64());
                     return false;
                 }
+                _server.closeConnection(_stream->peer_address().u64());
 
                 return true;
             }


### PR DESCRIPTION
When I was using the wallet, I found that I could not automate the management and had to go through the client. By looking at the code, it is found that wallet-api checks for errors when parsing the message. So I did two json checks in order to be able to use parse in on_raw_message and wallet/api.cpp in wallet/api_cli.cpp. Although this did not solve the underlying problem, it enabled the wallet-api to work properly.