### PR TITLE
stringstream -> boost:split

### DIFF
--- a/utility/string_helpers.cpp
+++ b/utility/string_helpers.cpp
@@ -13,23 +13,14 @@
 // limitations under the License.
 
 #include "string_helpers.h"
-#include <sstream>
+#include <boost/algorithm/string/split.hpp>
 
 namespace string_helpers
 {
-	template<typename Out>
-	void split(const std::string& s, char delim, Out result)
-	{
-		std::stringstream ss(s);
-		std::string item;
-		while (std::getline(ss, item, delim))
-			*(result++) = item;
-	}
-
 	std::vector<std::string> split(const std::string& s, char delim)
 	{
-		std::vector<std::string> elems;
-		split(s, delim, std::back_inserter(elems));
-		return elems;
+		std::vector<std::string> result;
+		boost::split(result, s, [&](char c){return c == delim;});
+		return result;
 	}
 }

--- a/utility/string_helpers.h
+++ b/utility/string_helpers.h
@@ -20,8 +20,4 @@
 namespace string_helpers
 {
 	std::vector<std::string> split(const std::string& s, char delim);
-
-#ifdef WIN32
-	std::wstring Utf8toUtf16(const char*);
-#endif // WIN32
 }


### PR DESCRIPTION
Make string_helpers::split use boost::split instead of string stream. 

- less code
- 3.4 times faster on my PC in Release build

Also removed Utf8toUtf16 from string_helpers which seems to be here by mistake. Actual used Utf8toUtf16 is defined in common.h/namespace beam