### PR TITLE
Change pending task count to 64

### DIFF
--- a/node/node.h
+++ b/node/node.h
@@ -654,7 +654,7 @@ private:
 			IExternalPOW* m_pSolver = nullptr;
 			uint64_t m_jobID = 0;
 
-			Task::Ptr m_ppTask[3]; // backlog of potentially being-mined currently
+			Task::Ptr m_ppTask[64]; // backlog of potentially being-mined currently
 			Task::Ptr& get_At(uint64_t);
 
 		} m_External;


### PR DESCRIPTION
It's common to send more than 3 jobs for a height in a very short time, so some solutions may get lost.

Increasing this value will save some miners.
