### PR TITLE
[Mining] Return final block hash in stratum response for a valid solution

### DIFF
--- a/node/node.cpp
+++ b/node/node.cpp
@@ -3733,10 +3733,16 @@ IExternalPOW::BlockFoundResult Node::Miner::OnMinedExternal()
         return IExternalPOW::solution_rejected;
     }
 
+    IExternalPOW::BlockFoundResult result(IExternalPOW::solution_accepted);
+    Merkle::Hash hv;
+    pTask->m_Hdr.get_Hash(hv);
+    result._blockhash = to_hex(hv.m_pData, hv.nBytes);
+
 	m_pTask = pTask;
     *m_pTask->m_pStop = true;
     m_pEvtMined->post();
-    return IExternalPOW::solution_accepted;
+
+    return result;
 }
 
 void Node::Miner::OnMined()

--- a/pow/external_pow.h
+++ b/pow/external_pow.h
@@ -20,7 +20,18 @@ namespace beam {
 
 class IExternalPOW {
 public:
-    enum BlockFoundResult { solution_accepted, solution_rejected, solution_expired };
+    enum BlockFoundResultCode { solution_accepted, solution_rejected, solution_expired };
+    
+    struct BlockFoundResult {
+        BlockFoundResult(BlockFoundResultCode code) : _code(code) {}
+        virtual ~BlockFoundResult() = default;
+
+        bool operator ==(BlockFoundResultCode code) { return _code == code; }
+        bool operator !=(BlockFoundResultCode code) { return _code != code; }
+
+        BlockFoundResultCode _code;
+        std::string _blockhash;
+    };
 
     using BlockFound = std::function<BlockFoundResult()>;
 

--- a/pow/stratum.cpp
+++ b/pow/stratum.cpp
@@ -68,6 +68,7 @@ namespace {
     DEF_LABEL(height);
     DEF_LABEL(nonceprefix);
     DEF_LABEL(forkheight);
+    DEF_LABEL(blockhash);
 #undef DEF_LABEL
 
 ResultCode parse_json(const void* buf, size_t bufSize, json& o) {
@@ -203,7 +204,8 @@ bool append_json_msg(io::FragmentWriter& packer, const Result& m) {
     o[l_code] = m.code;
     o[l_description] = m.description;
     if (!m.nonceprefix.empty()) o[l_nonceprefix] = m.nonceprefix;
-    if (m.forkheight != MaxHeight) o[l_forkheight] = m.forkheight;	
+    if (m.forkheight != MaxHeight) o[l_forkheight] = m.forkheight;
+    if (!m.blockhash.empty()) o[l_blockhash] = m.blockhash;
     return serialize_json_msg(packer, o);
 }
 

--- a/pow/stratum.h
+++ b/pow/stratum.h
@@ -124,6 +124,7 @@ struct Result : Message {
     ResultCode code=no_error;
     std::string description;
     std::string nonceprefix;
+    std::string blockhash;
     uint64_t forkheight = MaxHeight;
 
     Result() = default;

--- a/pow/stratum_server.cpp
+++ b/pow/stratum_server.cpp
@@ -176,6 +176,9 @@ bool Server::on_solution(uint64_t from, const Solution& sol) {
         stratumCode = stratum::solution_expired;
     }
     Result res(sol.id, stratumCode);
+    if (result == IExternalPOW::solution_accepted) {
+        res.blockhash = result._blockhash;
+    }
     append_json_msg(_fw, res);
     bool sent = _connections[from]->send_msg(_currentMsg, true);
     _currentMsg.clear();


### PR DESCRIPTION
**Abstract:** For mining pools it is important to know which block was solved when a solution is submitted (so it could internally match the current job to the actual block mined afterwards). Presently, Beam node is not offering a way of knowing that, and a mining pool (such as 2Miners.com, but not limited to it, of course) needs to verify that the block that the pool has found a solution for was successfully accepted to the blockchain afterwards to coin the mined block and distribute rewards.

**Solution**: Return a new JSON field in the Stratum response to a solution submission, `blockhash`, that contains the final hash of the block (including the submitted PoW and nonce) that the submitted solution is for.