### PR TITLE
Applications should avoid to exit with a SIGINT

### DIFF
--- a/wallet/cli/cli.cpp
+++ b/wallet/cli/cli.cpp
@@ -2722,7 +2722,7 @@ int main(int argc, char* argv[]) {
             // TODO: this hungs app on OSX
             //lock_signals_in_this_thread();
             int ret = main_impl(argc, argv);
-            kill(0, SIGINT);
+            _Exit(0);
             return ret;
         }
     );


### PR DESCRIPTION
Applications that exit with a SIGINT can/will break their parent/calling applications.
If you called it through a python script, python script would exit, same for bash.
The worst part was if you tried to call a script, that called the CLI from a .desktop application file on Linux, X server dies.

This fixes it!