### PR TITLE
Implement register and unregister on wallet API, add tests

### DIFF
--- a/wallet/api/v6_0/wallet_api.h
+++ b/wallet/api/v6_0/wallet_api.h
@@ -118,6 +118,9 @@ namespace beam::wallet
         }
 
         template<typename T>
+        void onHandleRegisterUnregister(bool doRegister, const JsonRpcId &id, const T& data);
+
+        template<typename T>
         void onHandleIssueConsume(bool issue, const JsonRpcId& id, const T& data);
 
         template<typename T>
@@ -135,6 +138,8 @@ namespace beam::wallet
         WALLET_API_METHODS(PARSE_FUNC)
         #undef PARSE_FUNC
 
+        template<typename T>
+        std::pair<T, IWalletApi::MethodInfo> onParseRegisterUnregister(bool doRegister, const JsonRpcId& id, const json& params);
         template<typename T>
         std::pair<T, IWalletApi::MethodInfo> onParseIssueConsume(bool issue, const JsonRpcId& id, const json& params);
 

--- a/wallet/api/v6_0/wallet_api_defs.h
+++ b/wallet/api/v6_0/wallet_api_defs.h
@@ -56,6 +56,8 @@ namespace beam::wallet
     macro(AddrList,              "addr_list",               API_READ_ACCESS,  API_SYNC,  APPS_ALLOWED)   \
     macro(ValidateAddress,       "validate_address",        API_READ_ACCESS,  API_SYNC,  APPS_ALLOWED)   \
     macro(Send,                  "tx_send",                 API_WRITE_ACCESS, API_SYNC,  APPS_ALLOWED)   \
+    macro(Register,              "tx_asset_register",       API_WRITE_ACCESS, API_SYNC,  APPS_ALLOWED /* TODO: I feel like apps shouldn't be allowed to do this, but I also don't know what this refers to in "apps". */)   \
+    macro(Unregister,            "tx_asset_unregister",     API_WRITE_ACCESS, API_SYNC,  APPS_ALLOWED)   \
     macro(Issue,                 "tx_asset_issue",          API_WRITE_ACCESS, API_SYNC,  APPS_BLOCKED)   \
     macro(Consume,               "tx_asset_consume",        API_WRITE_ACCESS, API_SYNC,  APPS_BLOCKED)   \
     macro(TxAssetInfo,           "tx_asset_info",           API_WRITE_ACCESS, API_SYNC,  APPS_ALLOWED)   \
@@ -165,6 +167,32 @@ namespace beam::wallet
         std::string comment;
         TxParameters txParameters;
         TxAddressType addressType = TxAddressType::Unknown;
+
+        struct Response
+        {
+            TxID txId;
+        };
+    };
+
+    struct Register
+    {
+        Amount fee = 0;
+        std::string asset_meta;
+        boost::optional<CoinIDList> coins;
+        boost::optional<TxID> txId;
+
+        struct Response
+        {
+            TxID txId;
+        };
+    };
+
+    struct Unregister
+    {
+        Amount fee = 0;
+        std::string asset_meta;
+        boost::optional<CoinIDList> coins;
+        boost::optional<TxID> txId;
 
         struct Response
         {

--- a/wallet/api/v6_0/wallet_api_parse.cpp
+++ b/wallet/api/v6_0/wallet_api_parse.cpp
@@ -617,6 +617,64 @@ namespace beam::wallet
         return std::make_pair(txDelete, MethodInfo());
     }
 
+    std::pair<Register, IWalletApi::MethodInfo> WalletApi::onParseRegister(const JsonRpcId& id, const json& params)
+    {
+        return onParseRegisterUnregister<Register>(false, id, params);
+    }
+
+    std::pair<Unregister, IWalletApi::MethodInfo> WalletApi::onParseUnregister(const JsonRpcId& id, const json& params)
+    {
+        return onParseRegisterUnregister<Unregister>(false, id, params);
+    }
+
+    template <typename T>
+    std::pair<T, IWalletApi::MethodInfo> WalletApi::onParseRegisterUnregister(bool doRegister, const JsonRpcId& id, const json& params)
+    {
+        T data;
+        data.asset_meta = getMandatoryParam<std::string>(params, "asset_meta");
+
+        WalletAssetMeta meta(data.asset_meta);
+        // ensure that asset meta has all required parameters at a minimum
+        const auto chkMetadata = [&](bool cond, const std::string& param) -> auto {
+            if (cond) {
+                throw jsonrpc_exception(ApiError::InvalidParamsJsonRpc, param + " is a required asset descriptor, but was not included.");
+            }
+        };
+
+        chkMetadata(meta.GetSchemaVersion() == 0, "SCH_VER");
+        chkMetadata(meta.GetName().empty(), "N");
+        chkMetadata(meta.GetShortName().empty(), "SN");
+        chkMetadata(meta.GetUnitName().empty(), "UN");
+        chkMetadata(meta.GetNthUnitName().empty(), "NTHUN");
+
+        if (hasParam(params, "coins"))
+        {
+            data.coins = readCoinsParameter(id, params);
+        }
+
+        data.fee = getBeamFeeParam(params, "fee");
+        data.txId = getOptionalParam<ValidTxID>(params, "txId");
+
+        MethodInfo info;
+        info.fee = data.fee;
+
+        if (doRegister)
+        {
+            // is there an actual Beam to Groth value somewhere in wallet API source?
+            // additionally, is this correct behaviour?
+            info.spend[Asset::s_BeamID] = (Amount) 3000 * 100000000;
+        }
+        else
+        {
+            info.receive[Asset::s_BeamID] = (Amount) 3000 * 100000000;
+        }
+
+        return std::make_pair(data, info);
+    }
+
+    template std::pair<Register, IWalletApi::MethodInfo> WalletApi::onParseRegisterUnregister(bool doRegister, const JsonRpcId& id, const json& params);
+    template std::pair<Unregister, IWalletApi::MethodInfo> WalletApi::onParseRegisterUnregister(bool doRegister, const JsonRpcId& id, const json& params);
+
     std::pair<Issue, IWalletApi::MethodInfo> WalletApi::onParseIssue(const JsonRpcId& id, const json& params)
     {
         return onParseIssueConsume<Issue>(true, id, params);
@@ -1072,6 +1130,34 @@ namespace beam::wallet
     }
 
     void WalletApi::getResponse(const JsonRpcId& id, const Send::Response& res, json& msg)
+    {
+        msg = json
+        {
+            {JsonRpcHeader, JsonRpcVersion},
+            {"id", id},
+            {"result",
+                {
+                    {"txId", std::to_string(res.txId)}
+                }
+            }
+        };
+    }
+
+    void WalletApi::getResponse(const JsonRpcId& id, const Register::Response& res, json& msg)
+    {
+        msg = json
+        {
+                {JsonRpcHeader, JsonRpcVersion},
+                {"id", id},
+                {"result",
+                    {
+                        {"txId", std::to_string(res.txId)}
+                    }
+                }
+        };
+    }
+
+    void WalletApi::getResponse(const JsonRpcId& id, const Unregister::Response& res, json& msg)
     {
         msg = json
         {

--- a/wallet/core/assets_utils.cpp
+++ b/wallet/core/assets_utils.cpp
@@ -218,7 +218,7 @@ namespace beam::wallet {
 
     unsigned WalletAssetMeta::GetSchemaVersion() const
     {
-        const auto it = _values.find(SHORT_NAME_KEY);
+        const auto it = _values.find(VERSION_KEY);
         return it != _values.end() ? std::to_unsigned(it->second, false) : 0;
     }
 


### PR DESCRIPTION
I felt like the wallet API was a bit lacking in it's ability to manage assets (and this does somewhat hinder testing on the Go SDK), so I added the ability to register and deregister assets via the RPC.

Some use cases this could be good for:
- A user is developing a dApp with an associated CA, and they need to deploy their CA alongside their test as they may be using a self-hosted chain (kinda like I do in the Go SDK)
- A user is intending to delist the CA, and has a script to deregister the CA as soon as all assets have been reclaimed