### PR TITLE
Fix gcc-11 compilation errors

### DIFF
--- a/3rdparty/libbitcoin/include/bitcoin/bitcoin/wallet/dictionary.hpp
+++ b/3rdparty/libbitcoin/include/bitcoin/bitcoin/wallet/dictionary.hpp
@@ -20,6 +20,7 @@
 #define LIBBITCOIN_WALLET_DICTIONARY_HPP
 
 #include <array>
+#include <cstddef>
 #include <vector>
 #include <bitcoin/bitcoin/compat.hpp>
 

--- a/3rdparty/yas/detail/type_traits/type_traits.hpp
+++ b/3rdparty/yas/detail/type_traits/type_traits.hpp
@@ -37,7 +37,15 @@
 #define __yas__detail__type_traits__type_traits_hpp
 
 #include <yas/detail/config/endian.hpp>
+
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wnonnull"
+#endif
 #include <yas/detail/type_traits/has_method_serialize.hpp>
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+#	pragma GCC diagnostic pop
+#endif
 #include <yas/detail/type_traits/has_function_serialize.hpp>
 #include <yas/version.hpp>
 

--- a/bvm/wasm_interpreter.h
+++ b/bvm/wasm_interpreter.h
@@ -17,6 +17,8 @@
 #include "../utility/containers.h"
 #include "../utility/byteorder.h"
 
+#include <limits>
+
 namespace beam {
 namespace Wasm {
 

--- a/core/ecc.h
+++ b/core/ecc.h
@@ -157,6 +157,10 @@ namespace ECC
 
 	typedef beam::Amount Amount;
 
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 	struct SignatureBase
 	{
 		//	Generalized Schnorr's signature. Very flexible.
@@ -191,7 +195,9 @@ namespace ECC
 	protected:
 		bool IsValidPartialInternal(const Config&, MultiMac& mm, const Hash::Value& msg, const Scalar* pK, const Point::Native* pPk, const Point::Native& noncePub) const;
 	};
-
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+#	pragma GCC diagnostic pop
+#endif
 
 	struct Signature
 		:public SignatureBase

--- a/node/processor.cpp
+++ b/node/processor.cpp
@@ -4365,7 +4365,8 @@ void NodeProcessor::BlockInterpretCtx::Der::SetBwd(ByteBuffer& buf, uint32_t nPo
 	size_t nVal = buf.size() - nPortion;
 	reset(&buf.front() + nVal, nPortion);
 
-	buf.resize(nVal); // it's safe to call resize() while the buffer is being used, coz std::vector does NOT reallocate on shrink
+	if (nVal < buf.size()) // to avoid stringop-overflow warning
+		buf.resize(nVal); // it's safe to call resize() while the buffer is being used, coz std::vector does NOT reallocate on shrink
 }
 
 bool NodeProcessor::ValidateUniqueNoDup(BlockInterpretCtx& bic, const Blob& key, const Blob* pVal)

--- a/utility/config.h
+++ b/utility/config.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <limits>
 #include <string>
 #include <stdint.h>
 #include <unordered_map>

--- a/utility/unittest/asyncevent_test.cpp
+++ b/utility/unittest/asyncevent_test.cpp
@@ -15,6 +15,7 @@
 #include "utility/io/asyncevent.h"
 #include <future>
 #include <iostream>
+#include <thread>
 
 using namespace beam::io;
 using namespace std;

--- a/utility/unittest/reactor_test.cpp
+++ b/utility/unittest/reactor_test.cpp
@@ -19,6 +19,7 @@
 #include "utility/logger.h"
 #include <future>
 #include <iostream>
+#include <thread>
 
 using namespace beam;
 using namespace beam::io;

--- a/wallet/client/filter.h
+++ b/wallet/client/filter.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 #pragma once
 
+#include <cstddef>
 #include <vector>
 
 namespace beam::wallet

--- a/wallet/laser/mediator.cpp
+++ b/wallet/laser/mediator.cpp
@@ -117,8 +117,10 @@ void Mediator::OnRolledBack()
             m_pWalletDB->saveLaserChannel(*channel);
             channel->Subscribe();
 
-            m_channels[channel->get_chID()] =
-                std::unique_ptr<Channel>(channel.release());
+            auto chID = channel->get_chID();
+            if (chID != nullptr)
+                m_channels[chID] =
+                    std::unique_ptr<Channel>(channel.release());
         }
     }
 


### PR DESCRIPTION
These changes fix compilation errors occurred when compiling with gcc-11.
See https://gcc.gnu.org/gcc-11/porting_to.html