### PR TITLE
Fix gcc-11 compilation errors: nonnull warning

### DIFF
--- a/wallet/laser/mediator.cpp
+++ b/wallet/laser/mediator.cpp
@@ -117,8 +117,10 @@ void Mediator::OnRolledBack()
             m_pWalletDB->saveLaserChannel(*channel);
             channel->Subscribe();
 
-            m_channels[channel->get_chID()] =
-                std::unique_ptr<Channel>(channel.release());
+            auto chID = channel->get_chID();
+            if (chID != nullptr)
+                m_channels[chID] =
+                    std::unique_ptr<Channel>(channel.release());
         }
     }
 


### PR DESCRIPTION
These changes fix compilation errors occurred when compiling with gcc-11.
See https://gcc.gnu.org/gcc-11/porting_to.html