### PR TITLE
Update default_peers.cpp

### DIFF
--- a/wallet/core/default_peers.cpp
+++ b/wallet/core/default_peers.cpp
@@ -24,16 +24,8 @@ namespace beam
             "eu-nodes.testnet.beam.mw:8100",
             "ap-nodes.testnet.beam.mw:8100"
 #elif defined(BEAM_MAINNET)
-            "ap-nodes.mainnet.beam.mw:8100",
             "eu-nodes.mainnet.beam.mw:8100",
             "us-nodes.mainnet.beam.mw:8100",
-            "ap-hk-nodes.mainnet.beam.mw:8100",
-            "45.63.100.240:10127",
-            "usa.raskul.com:10174",
-            "canada.raskul.com:10174",
-            "japan.raskul.com:10127",
-            "india.raskul.com:10127",
-            "oz.raskul.com:10127",
 #elif defined(BEAM_BEAMX)
             "us-node01.beamx.beam.mw:8100",
             "us-node02.beamx.beam.mw:8100",


### PR DESCRIPTION
#1955 
Now uses the same bootstrap nodes as the desktop wallet([here](https://github.com/BeamMW/beam/blob/master/wallet/core/default_peers.cpp))