### PR TITLE
Version 0.4: Better display of multiple contract calls. Many enhancements and corrections.

### DIFF
--- a/bvm/ManagerStd.cpp
+++ b/bvm/ManagerStd.cpp
@@ -512,6 +512,11 @@ namespace bvm2 {
 		m_Pending.m_pBlocker = nullptr;
 	}
 
+	void ManagerStd::Reset()
+	{
+		OnReset();
+	}
+
 	void ManagerStd::StartRun(uint32_t iMethod)
 	{
 		OnReset();

--- a/bvm/ManagerStd.h
+++ b/bvm/ManagerStd.h
@@ -60,7 +60,6 @@ namespace beam::bvm2 {
 		void Comm_OnNewMsg(const Blob&, Comm::Channel&);
 		void Comm_OnNewMsg();
 
-	protected:
 		void SelectContext(bool bDependent, uint32_t nChargeNeeded) override;
 		bool get_HdrAt(Block::SystemState::Full&) override;
 		void VarsEnum(const Blob& kMin, const Blob& kMax, IReadVars::Ptr&) override;
@@ -92,6 +91,7 @@ namespace beam::bvm2 {
 		// results
 		std::ostringstream m_Out;
 
+		void Reset();
 		void StartRun(uint32_t iMethod);
 	};
 } // namespace

--- a/bvm/bvm2.cpp
+++ b/bvm/bvm2.cpp
@@ -1350,6 +1350,11 @@ namespace bvm2 {
 			((ProcessorPlusEnv_Contract*) this)->SetVarKeyFromShader(vk, nType, key, false);
 			key = vk.ToBlob();
 		}
+		else
+		{
+			// impose the same restriction for apps
+			Exc::Test(key.n <= Limits::VarKeySize);
+		}
 
 		Blob res;
 		LoadVar(key, res);
@@ -1389,6 +1394,11 @@ namespace bvm2 {
 
 			((ProcessorPlusEnv_Contract*) this)->SetVarKeyFromShader(vk, nType, key, false);
 			key = vk.ToBlob();
+		}
+		else
+		{
+			// impose the same restriction for apps
+			Exc::Test(key.n <= Limits::VarKeySize);
 		}
 
 		Blob res;
@@ -1446,6 +1456,11 @@ namespace bvm2 {
 
 			((ProcessorPlusEnv_Contract*) this)->SetVarKeyFromShader(vk, nType, key, true);
 			key = vk.ToBlob();
+		}
+		else
+		{
+			Exc::Test(key.n <= Limits::VarKeySize);
+			Exc::Test(nVal <= Limits::VarSize_4);
 		}
 
 		return SaveVar(key, Blob(pVal, nVal));

--- a/bvm/bvm2.cpp
+++ b/bvm/bvm2.cpp
@@ -478,7 +478,7 @@ namespace bvm2 {
 
 	uint32_t ProcessorContract::get_WasmVersion()
 	{
-		return IsPastFork(6) ? 1 : 0;
+		return IsPastFork_<6>() ? 1 : 0;
 	}
 
 	void Processor::Compiler::Compile(ByteBuffer& res, const Blob& src, Kind kind, Wasm::Compiler::DebugInfo* pDbgInfo /* = nullptr */)
@@ -1370,7 +1370,7 @@ namespace bvm2 {
 	}
 	BVM_METHOD_HOST(LoadVarEx)
 	{
-		Exc::Test(IsPastHF4());
+		Exc::Test(IsPastFork_<4>());
 
 		std::setmin(nKeyBufSize, Limits::VarKeySize);
 		Exc::Test(nKey <= nKeyBufSize);
@@ -1445,7 +1445,7 @@ namespace bvm2 {
 		auto nCalleeStackMax = m_Stack.m_BytesCurrent;
 		uint8_t* pArgsPtr = nullptr;
 
-		bool bPastHF6 = IsPastFork(6);
+		bool bPastHF6 = IsPastFork_<6>();
 		if (!bPastHF6)
 		{
 			nFlags &= 0xff; // before HF6 it was uint8_t
@@ -1559,7 +1559,7 @@ namespace bvm2 {
 
 	BVM_METHOD_HOST(UpdateShader)
 	{
-		Exc::Test(IsPastHF4());
+		Exc::Test(IsPastFork_<4>());
 		TestCanWrite();
 
 		TestVarSize(nVal);
@@ -1793,7 +1793,7 @@ namespace bvm2 {
 	BVM_METHOD(get_ForkHeight)
 	{
 		if (Kind::Contract == get_Kind())
-			Exc::Test(IsPastFork(5));
+			Exc::Test(IsPastFork_<5>());
 
 		const Rules& r = Rules::get();
 		return (iFork >= _countof(r.pForks)) ? MaxHeight : r.pForks[iFork].m_Height;
@@ -1805,7 +1805,7 @@ namespace bvm2 {
 	{
 		if (Kind::Contract == get_Kind())
 		{
-			Exc::Test(IsPastFork(6));
+			Exc::Test(IsPastFork_<6>());
 			DischargeUnits(Limits::Cost::LoadVar);
 		}
 
@@ -2056,7 +2056,7 @@ namespace bvm2 {
 	BVM_METHOD(HashClone)
 	{
 		if (Kind::Contract == get_Kind())
-			Exc::Test(IsPastHF4());
+			Exc::Test(IsPastFork_<4>());
 
 		return CloneHash(m_DataProcessor.FindStrict(pHash));
 	}
@@ -2235,7 +2235,7 @@ namespace bvm2 {
 	BVM_METHOD(Secp_Point_ExportEx)
 	{
 		if (Kind::Contract == get_Kind())
-			Exc::Test(IsPastHF4());
+			Exc::Test(IsPastFork_<4>());
 
 		DischargeUnits(Limits::Cost::Secp_Point_Export);
 		m_Secp.m_Point.FindStrict(p).m_Val.Export(get_AddrAsW<ECC::Point::Storage>(res));
@@ -3876,7 +3876,7 @@ namespace bvm2 {
 	// Shader aux
 	void ProcessorContract::AddRemoveShader(const ContractID& cid, const Blob* pCode)
 	{
-		AddRemoveShader(cid, pCode, IsPastHF4());
+		AddRemoveShader(cid, pCode, IsPastFork_<4>());
 	}
 
 	void ProcessorContract::AddRemoveShader(const ContractID& cid, const Blob* pCode, bool bFireEvent)

--- a/bvm/bvm2.h
+++ b/bvm/bvm2.h
@@ -295,6 +295,13 @@ namespace bvm2 {
 			return Rules::get().IsPastFork_<iFork>(get_Height() + 1);
 		}
 
+		virtual void LoadVar(const Blob&, Blob& res) { res.n = 0; } // res is temporary
+		virtual void LoadVarEx(Blob& key, Blob& res, bool bExact, bool bBigger) {
+			key.n = 0;
+			res.n = 0;
+		}
+		virtual uint32_t SaveVar(const Blob&, const Blob& val) { return 0; }
+
 	public:
 
 		enum struct Kind {
@@ -329,6 +336,8 @@ namespace bvm2 {
 		:public Processor
 	{
 	protected:
+
+		friend struct ProcessorPlusEnv;
 
 		void SetVarKey(VarKey&);
 		void SetVarKey(VarKey&, uint8_t nTag, const Blob&);
@@ -396,14 +405,8 @@ namespace bvm2 {
 		virtual void DischargeUnits(uint32_t size) override;
 		virtual uint32_t get_WasmVersion() override;
 
-		virtual void LoadVar(const Blob&, Blob& res) { res.n = 0; } // res is temporary
-		virtual uint32_t SaveVar(const Blob&, const Blob& val) { return 0; }
 		virtual uint32_t OnLog(const Blob&, const Blob& val) { return 0; }
 
-		virtual void LoadVarEx(Blob& key, Blob& res, bool bExact, bool bBigger) {
-			key.n = 0;
-			res.n = 0;
-		}
 
 		virtual Asset::ID AssetCreate(const Asset::Metadata&, const PeerID&, Amount& valDeposit) { return 0; }
 		virtual bool AssetEmit(Asset::ID, const PeerID&, AmountSigned) { return false; }

--- a/bvm/bvm2.h
+++ b/bvm/bvm2.h
@@ -291,7 +291,7 @@ namespace bvm2 {
 		bool IsPastFork(uint32_t iFork)
 		{
 			assert(iFork < _countof(Rules::get().pForks));
-			return get_Height() + 1 >= Rules::get().pForks[iFork].m_Height;
+			return Rules::get().IsPastFork(get_Height() + 1, iFork);
 		}
 
 		bool IsPastHF4() {

--- a/bvm/bvm2.h
+++ b/bvm/bvm2.h
@@ -288,15 +288,11 @@ namespace bvm2 {
 
 		const HeightPos* FromWasmOpt(Wasm::Word pPos, HeightPos& buf);
 
-		bool IsPastFork(uint32_t iFork)
+		template <uint32_t iFork>
+		bool IsPastFork_()
 		{
-			assert(iFork < _countof(Rules::get().pForks));
-			return Rules::get().IsPastFork(get_Height() + 1, iFork);
-		}
-
-		bool IsPastHF4() {
 			// current height does not include the current being-interpreted block
-			return IsPastFork(4);
+			return Rules::get().IsPastFork_<iFork>(get_Height() + 1);
 		}
 
 	public:
@@ -433,7 +429,7 @@ namespace bvm2 {
 
 		void TestVarSize(uint32_t n)
 		{
-			uint32_t nMax = IsPastHF4() ? Limits::VarSize_4 : Limits::VarSize_0;
+			uint32_t nMax = IsPastFork_<4>() ? Limits::VarSize_4 : Limits::VarSize_0;
 			Exc::Test(n <= nMax);
 		}
 

--- a/bvm/bvm2_opcodes.h
+++ b/bvm/bvm2_opcodes.h
@@ -512,6 +512,9 @@
 	macro(0x19, void     , StackFree) \
 	macro(0x1A, void*    , Heap_Alloc) \
 	macro(0x1B, void     , Heap_Free) \
+	macro(0x20, uint32_t , LoadVar) \
+	macro(0x21, uint32_t , SaveVar) \
+	macro(0x27, void     , LoadVarEx) \
 	macro(0x28, void     , Halt) \
 	macro(0x2A, uint32_t , get_AssetInfo) \
 	macro(0x2B, void     , HashWrite) \
@@ -550,14 +553,11 @@
 	macro(0xB0, uint8_t  , VerifyBeamHashIII) \
 
 #define BVMOpsAll_Contract(macro) \
-	macro(0x20, uint32_t , LoadVar) \
-	macro(0x21, uint32_t , SaveVar) \
 	macro(0x22, uint32_t , EmitLog) \
 	macro(0x23, void     , CallFar) \
 	macro(0x24, uint32_t , get_CallDepth) \
 	macro(0x25, void     , get_CallerCid) \
 	macro(0x26, void     , UpdateShader) \
-	macro(0x27, void     , LoadVarEx) \
 	macro(0x29, void     , AddSig) \
 	macro(0x30, void     , FundsLock) \
 	macro(0x31, void     , FundsUnlock) \

--- a/bvm/ethash_service/shaders_ethash.h
+++ b/bvm/ethash_service/shaders_ethash.h
@@ -14,28 +14,9 @@
 
 #pragma once
 
+#include "../bvm2.h"
+
 namespace Shaders
 {
-	using PubKey = ECC::Point;
-	using Secp_point_data = ECC::Point;
-	using Secp_point_dataEx = ECC::Point::Storage;
-	using Secp_scalar_data = ECC::Scalar;
-	using AssetID = beam::Asset::ID;
-	using ContractID = ECC::uintBig;
-	using HashValue = ECC::uintBig;
-	using beam::Amount;
-	using beam::Height;
-	using beam::Timestamp;
-	using beam::HeightPos;
-
-	template<bool bToShader, typename T>
-	inline void ConvertOrd(T& x)
-	{
-		if constexpr (bToShader)
-			x = beam::ByteOrder::to_le(x);
-		else
-			x = beam::ByteOrder::from_le(x);
-	}
-
 #include "bvm/Shaders/Ethash.h"
 }

--- a/bvm/wasm_interpreter.h
+++ b/bvm/wasm_interpreter.h
@@ -385,7 +385,7 @@ namespace Wasm {
 #endif // WASM_INTERPRETER_DEBUG
 
 		Processor()
-			:m_Instruction(Reader::Mode::Emulate_x86)
+			:m_Instruction(Reader::Mode::Standard)
 		{
 		}
 

--- a/core/block_crypt.h
+++ b/core/block_crypt.h
@@ -437,10 +437,15 @@ namespace beam
 
 		static void Fail_Fork(uint32_t iFork);
 
-		void TestForkAtLeast(Height h, uint32_t iFork) const
+		bool IsPastFork(Height h, uint32_t iFork) const
 		{
 			assert(iFork < _countof(pForks));
-			if (h < pForks[iFork].m_Height)
+			return (h >= pForks[iFork].m_Height);
+		}
+
+		void TestForkAtLeast(Height h, uint32_t iFork) const
+		{
+			if (!IsPastFork(h, iFork))
 				Fail_Fork(iFork);
 		}
 

--- a/core/block_crypt.h
+++ b/core/block_crypt.h
@@ -443,10 +443,24 @@ namespace beam
 			return (h >= pForks[iFork].m_Height);
 		}
 
+		template <uint32_t iFork>
+		bool IsPastFork_(Height h) const
+		{
+			static_assert(iFork < _countof(pForks), "");
+			return IsPastFork(h, iFork);
+		}
+
 		void TestForkAtLeast(Height h, uint32_t iFork) const
 		{
 			if (!IsPastFork(h, iFork))
 				Fail_Fork(iFork);
+		}
+
+		template <uint32_t iFork>
+		void TestForkAtLeast_(Height h) const
+		{
+			static_assert(iFork < _countof(pForks), "");
+			TestForkAtLeast(h, iFork);
 		}
 
 		void TestEnabledCA() const

--- a/core/block_rw.cpp
+++ b/core/block_rw.cpp
@@ -495,7 +495,7 @@ namespace beam
 		if (!(m_Cwp.m_hvRootLive == hv))
 			ThrowBadData();
 
-		if (m_Tip.m_Height >= Rules::get().pForks[3].m_Height)
+		if (Rules::get().IsPastFork(m_Tip.m_Height, 3))
 		{
 			BEAM_VERIFY(v.get_Utxos(hv));
 			if (m_Tip.m_Kernels != hv)
@@ -521,7 +521,7 @@ namespace beam
 			return false;
 
 		const Rules& r = Rules::get();
-		if (m_Tip.m_Height >= r.pForks[2].m_Height)
+		if (r.IsPastFork(m_Tip.m_Height, 2))
 		{
 			if (!ProceedShielded())
 				return false;
@@ -529,7 +529,7 @@ namespace beam
 			if (!ProceedAssets())
 				return false;
 
-			if (m_Tip.m_Height >= r.pForks[3].m_Height)
+			if (r.IsPastFork(m_Tip.m_Height, 3))
 			{
 				m_Der
 					& m_hvContracts
@@ -606,7 +606,7 @@ namespace beam
 				{
 					txo.m_pAsset.reset(new Asset::Proof);
 
-					if (h >= Rules::get().pForks[3].m_Height)
+					if (Rules::get().IsPastFork(h, 3))
 						m_Der & txo.m_pAsset->m_hGen;
 				}
 

--- a/core/block_rw.cpp
+++ b/core/block_rw.cpp
@@ -495,7 +495,7 @@ namespace beam
 		if (!(m_Cwp.m_hvRootLive == hv))
 			ThrowBadData();
 
-		if (Rules::get().IsPastFork(m_Tip.m_Height, 3))
+		if (Rules::get().IsPastFork_<3>(m_Tip.m_Height))
 		{
 			BEAM_VERIFY(v.get_Utxos(hv));
 			if (m_Tip.m_Kernels != hv)
@@ -521,7 +521,7 @@ namespace beam
 			return false;
 
 		const Rules& r = Rules::get();
-		if (r.IsPastFork(m_Tip.m_Height, 2))
+		if (r.IsPastFork_<2>(m_Tip.m_Height))
 		{
 			if (!ProceedShielded())
 				return false;
@@ -529,7 +529,7 @@ namespace beam
 			if (!ProceedAssets())
 				return false;
 
-			if (r.IsPastFork(m_Tip.m_Height, 3))
+			if (r.IsPastFork_<3>(m_Tip.m_Height))
 			{
 				m_Der
 					& m_hvContracts
@@ -606,7 +606,7 @@ namespace beam
 				{
 					txo.m_pAsset.reset(new Asset::Proof);
 
-					if (Rules::get().IsPastFork(h, 3))
+					if (Rules::get().IsPastFork_<3>(h))
 						m_Der & txo.m_pAsset->m_hGen;
 				}
 

--- a/core/serialization_adapters.h
+++ b/core/serialization_adapters.h
@@ -1063,7 +1063,7 @@ namespace detail
 			{
 				if (bRecoveryOnly)
 				{
-					if (*pRecoveryScheme >= beam::Rules::get().pForks[3].m_Height)
+					if (beam::Rules::get().IsPastFork(*pRecoveryScheme, 3))
 						ar & output.m_pAsset->m_hGen;
 				} else
 					savePtr(ar, output.m_pAsset);
@@ -1117,7 +1117,7 @@ namespace detail
 			{
 				if (bRecoveryOnly)
 				{
-					if (*pRecoveryScheme >= beam::Rules::get().pForks[3].m_Height)
+					if (beam::Rules::get().IsPastFork(*pRecoveryScheme, 3))
 					{
 						output.m_pAsset = std::make_unique<beam::Asset::Proof>();
 						ar & output.m_pAsset->m_hGen;

--- a/core/serialization_adapters.h
+++ b/core/serialization_adapters.h
@@ -1063,7 +1063,7 @@ namespace detail
 			{
 				if (bRecoveryOnly)
 				{
-					if (beam::Rules::get().IsPastFork(*pRecoveryScheme, 3))
+					if (beam::Rules::get().IsPastFork_<3>(*pRecoveryScheme))
 						ar & output.m_pAsset->m_hGen;
 				} else
 					savePtr(ar, output.m_pAsset);
@@ -1117,7 +1117,7 @@ namespace detail
 			{
 				if (bRecoveryOnly)
 				{
-					if (beam::Rules::get().IsPastFork(*pRecoveryScheme, 3))
+					if (beam::Rules::get().IsPastFork_<3>(*pRecoveryScheme))
 					{
 						output.m_pAsset = std::make_unique<beam::Asset::Proof>();
 						ar & output.m_pAsset->m_hGen;

--- a/explorer/adapter.cpp
+++ b/explorer/adapter.cpp
@@ -1000,7 +1000,7 @@ private:
 
                     Writer wr;
 
-                    if (r.IsPastFork(h, 6))
+                    if (r.IsPastFork_<6>(h))
                     {
                         a0++;
                         wr.m_json["x"] = 0u;

--- a/explorer/adapter.cpp
+++ b/explorer/adapter.cpp
@@ -1000,7 +1000,7 @@ private:
 
                     Writer wr;
 
-                    if (h >= r.pForks[6].m_Height)
+                    if (r.IsPastFork(h, 6))
                     {
                         a0++;
                         wr.m_json["x"] = 0u;

--- a/explorer/adapter.cpp
+++ b/explorer/adapter.cpp
@@ -288,6 +288,7 @@ private:
         struct MW {
             CountAndSize m_Inputs;
             CountAndSize m_Outputs;
+            uint64_t get_Utxos() const { return m_Outputs.m_Count - m_Inputs.m_Count; }
         } m_MW;
 
         struct Shielded {
@@ -301,6 +302,9 @@ private:
             uint64_t m_Invoked;
             uint64_t get_Sum() const {
                 return m_Created + m_Destroyed + m_Invoked;
+            }
+            uint64_t get_Active() const {
+                return m_Created - m_Destroyed;
             }
         } m_Contract;
 
@@ -691,10 +695,12 @@ private:
                 ret.m_sz[nLen++] = '-';
             }
 
-            nLen += NiceDecimal::Print(ret.m_sz + nLen, static_cast<uint64_t>(x));
-            if (get_ExpandWithCommas())
-                nLen = NiceDecimal::ExpandCommas(ret.m_sz, nLen);
+            uint32_t nLenUns = NiceDecimal::Print(ret.m_sz + nLen, static_cast<uint64_t>(x));;
 
+            if (get_ExpandWithCommas())
+                nLenUns = NiceDecimal::ExpandCommas(ret.m_sz + nLen, nLenUns);
+
+            nLen += nLenUns;
             assert(nLen < _countof(ret.m_sz));
         }
         else
@@ -2121,73 +2127,113 @@ private:
         return MakeTable(std::move(jAssets));
     }
 
-    struct AggrFormatter
+    void OnHdrs_Difficulty_Abs(json& j) { j.push_back(MakeTableHdr("Chainwork")); }
+    void OnHdrs_Difficulty_Abs(json& j, const Totals&, const Block::SystemState::Full& s) { j.push_back(NiceDecimal::MakeDifficulty(s.m_ChainWork).m_sz); }
+    void OnHdrs_Difficulty_Rel(json& j) { j.push_back(MakeTableHdr("Difficulty")); }
+    void OnHdrs_Difficulty_Rel(json& j, const Totals&, const Totals&, const Block::SystemState::Full& s) { j.push_back(NiceDecimal::MakeDifficulty(s.m_PoW.m_Difficulty).m_sz); }
+
+    void OnHdrs_Fee_Abs(json& j) { j.push_back(MakeTableHdr("T.Fee")); }
+    void OnHdrs_Fee_Abs(json& j, const Totals& t1, const Block::SystemState::Full&) { j.push_back(MakeObjAmount(t1.m_Fee)); }
+    void OnHdrs_Fee_Rel(json& j) { j.push_back(MakeTableHdr("Fee")); }
+    void OnHdrs_Fee_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full&) {
+        auto val = t0.m_Fee;
+        val.Negate();
+        val += t1.m_Fee;
+        j.push_back(MakeObjAmount(val));
+    }
+
+    void OnHdrs_Kernels_Abs(json& j) { j.push_back(MakeTableHdr("T.Txs")); }
+    void OnHdrs_Kernels_Abs(json& j, const Totals& t1, const Block::SystemState::Full&) { j.push_back(MakeDecimal(t1.m_Kernels.m_Count).m_sz); }
+    void OnHdrs_Kernels_Rel(json& j) { j.push_back(MakeTableHdr("Txs")); }
+    void OnHdrs_Kernels_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full&) { j.push_back(MakeDecimalDelta(t1.m_Kernels.m_Count - t0.m_Kernels.m_Count).m_sz); }
+
+    void OnHdrs_MwOutputs_Abs(json& j) { j.push_back(MakeTableHdr("T.MW.Outputs")); }
+    void OnHdrs_MwOutputs_Abs(json& j, const Totals& t1, const Block::SystemState::Full&) { j.push_back(MakeDecimal(t1.m_MW.m_Outputs.m_Count).m_sz); }
+    void OnHdrs_MwOutputs_Rel(json& j) { j.push_back(MakeTableHdr("MW.Outputs")); }
+    void OnHdrs_MwOutputs_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full&) { j.push_back(MakeDecimalDelta(t1.m_MW.m_Outputs.m_Count - t0.m_MW.m_Outputs.m_Count).m_sz); }
+
+    void OnHdrs_MwInputs_Abs(json& j) { j.push_back(MakeTableHdr("T.MW.Inputs")); }
+    void OnHdrs_MwInputs_Abs(json& j, const Totals& t1, const Block::SystemState::Full&) { j.push_back(MakeDecimal(t1.m_MW.m_Inputs.m_Count).m_sz); }
+    void OnHdrs_MwInputs_Rel(json& j) { j.push_back(MakeTableHdr("MW.Inputs")); }
+    void OnHdrs_MwInputs_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full&) { j.push_back(MakeDecimalDelta(t1.m_MW.m_Inputs.m_Count - t0.m_MW.m_Inputs.m_Count).m_sz); }
+
+    void OnHdrs_MwUtxos_Abs(json& j) { j.push_back(MakeTableHdr("T.MW.Utxos")); }
+    void OnHdrs_MwUtxos_Abs(json& j, const Totals& t1, const Block::SystemState::Full&) { j.push_back(MakeDecimal(t1.m_MW.get_Utxos()).m_sz); }
+    void OnHdrs_MwUtxos_Rel(json& j) { j.push_back(MakeTableHdr("MW.Utxos")); }
+    void OnHdrs_MwUtxos_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full&) { j.push_back(MakeDecimalDelta(t1.m_MW.get_Utxos() - t0.m_MW.get_Utxos()).m_sz); }
+
+    void OnHdrs_ShOutputs_Abs(json& j) { j.push_back(MakeTableHdr("T.SH.Outputs")); }
+    void OnHdrs_ShOutputs_Abs(json& j, const Totals& t1, const Block::SystemState::Full&) { j.push_back(MakeDecimal(t1.m_Shielded.m_Outputs).m_sz); }
+    void OnHdrs_ShOutputs_Rel(json& j) { j.push_back(MakeTableHdr("SH.Outputs")); }
+    void OnHdrs_ShOutputs_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full&) { j.push_back(MakeDecimalDelta(t1.m_Shielded.m_Outputs - t0.m_Shielded.m_Outputs).m_sz); }
+
+    void OnHdrs_ShInputs_Abs(json& j) { j.push_back(MakeTableHdr("T.SH.Inputs")); }
+    void OnHdrs_ShInputs_Abs(json& j, const Totals& t1, const Block::SystemState::Full&) { j.push_back(MakeDecimal(t1.m_Shielded.m_Inputs).m_sz); }
+    void OnHdrs_ShInputs_Rel(json& j) { j.push_back(MakeTableHdr("SH.Inputs")); }
+    void OnHdrs_ShInputs_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full&) { j.push_back(MakeDecimalDelta(t1.m_Shielded.m_Inputs - t0.m_Shielded.m_Inputs).m_sz); }
+
+    void OnHdrs_ContractsActive_Abs(json& j) { j.push_back(MakeTableHdr("T.Contracts")); }
+    void OnHdrs_ContractsActive_Abs(json& j, const Totals& t1, const Block::SystemState::Full&) { j.push_back(MakeDecimal(t1.m_Contract.get_Active()).m_sz); }
+    void OnHdrs_ContractsActive_Rel(json& j) { j.push_back(MakeTableHdr("Contracts")); }
+    void OnHdrs_ContractsActive_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full&) { j.push_back(MakeDecimalDelta(t1.m_Contract.get_Active() - t0.m_Contract.get_Active()).m_sz); }
+
+    void OnHdrs_ContractCalls_Abs(json& j) { j.push_back(MakeTableHdr("T.ContractCalls")); }
+    void OnHdrs_ContractCalls_Abs(json& j, const Totals& t1, const Block::SystemState::Full&) { j.push_back(MakeDecimal(t1.m_Contract.get_Sum()).m_sz); }
+    void OnHdrs_ContractCalls_Rel(json& j) { j.push_back(MakeTableHdr("ContractCalls")); }
+    void OnHdrs_ContractCalls_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full&) { j.push_back(MakeDecimalDelta(t1.m_Contract.get_Sum() - t0.m_Contract.get_Sum()).m_sz); }
+
+    static uint64_t get_ChainSize(Height h, const Totals& t, bool bArchieve)
     {
-        bool m_Rel = true;
-        bool m_Abs = true;
+        // size estimation
+        uint64_t ret = 
+            static_cast<uint64_t>(sizeof(Block::SystemState::Sequence::Element)) * (h - Rules::HeightGenesis + 1) +
+            t.m_Kernels.m_Size +
+            t.m_MW.m_Outputs.m_Size;
 
-        template <typename T1, typename T2>
-        void PushValWithTotal(json& res, T1&& x, T2&& dx) const
-        {
-            //json jRow = json::array();
-            //jRow.push_back(std::move(x));
-            //jRow.push_back(std::move(dx));
+        if (bArchieve)
+            ret += t.m_MW.m_Inputs.m_Count * sizeof(ECC::Point);
+        else
+            ret -= t.m_MW.m_Inputs.m_Size;
 
-            //json jRows = json::array();
-            //jRows.push_back(std::move(jRow));
+        return ret;
+    }
 
-            //res.push_back(MakeTable(std::move(jRows)));
 
-            //res.push_back(std::move(dx));
-            //res.push_back(std::move(x));
+    void OnHdrs_SizeArchieve_Abs(json& j) { j.push_back(MakeTableHdr("Size.Archieve")); }
+    void OnHdrs_SizeArchieve_Abs(json& j, const Totals& t1, const Block::SystemState::Full& s) { j.push_back(MakeDecimal(get_ChainSize(s.m_Height, t1, true)).m_sz); }
+    void OnHdrs_SizeArchieve_Rel(json& j) { j.push_back(MakeTableHdr("D.Size.Archieve")); }
+    void OnHdrs_SizeArchieve_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full& s) { j.push_back(MakeDecimalDelta(get_ChainSize(s.m_Height, t1, true) - get_ChainSize(s.m_Height - 1, t0, true)).m_sz); }
 
-            if (m_Rel)
-            {
-                if (m_Abs)
-                {
-                    res.push_back(MakeTable({
-                        { std::move(x) },
-                        { std::move(dx) } }));
-                }
-                else
-                    res.push_back(std::move(dx));
-            }
-            else
-            {
-                if (m_Abs)
-                    res.push_back(std::move(x));
-                else
-                    res.push_back("");
-            }
-        }
-    };
+    void OnHdrs_SizeCompressed_Abs(json& j) { j.push_back(MakeTableHdr("Size.Compressed")); }
+    void OnHdrs_SizeCompressed_Abs(json& j, const Totals& t1, const Block::SystemState::Full& s) { j.push_back(MakeDecimal(get_ChainSize(s.m_Height, t1, false)).m_sz); }
+    void OnHdrs_SizeCompressed_Rel(json& j) { j.push_back(MakeTableHdr("D.Size.Compressed")); }
+    void OnHdrs_SizeCompressed_Rel(json& j, const Totals& t1, const Totals& t0, const Block::SystemState::Full& s) { j.push_back(MakeDecimalDelta(get_ChainSize(s.m_Height, t1, false) - get_ChainSize(s.m_Height - 1, t0, false)).m_sz); }
 
-    json get_hdrs(uint64_t hMax, uint64_t nMax, bool bRel, bool bAbs) override
+    json get_hdrs(uint64_t hMax, uint64_t nMax, uint32_t fAbs, uint32_t fRel) override
     {
         std::setmin(nMax, 2048u);
         std::setmin(hMax, _nodeBackend.m_Cursor.m_Full.m_Height);
 
         json jRet = json::array();
-        jRet.push_back(json::array({
-            MakeTableHdr("Height"),
-            MakeTableHdr("Timestamp"),
-            MakeTableHdr("Hash"),
-            MakeTableHdr("Difficulty"),
-            MakeTableHdr("Fees"),
-            MakeTableHdr("Txs"),
-            MakeTableHdr("MW.Outs"),
-            MakeTableHdr("MW.Ins"),
-            MakeTableHdr("Sh.Outs"),
-            MakeTableHdr("Sh.Ins"),
-            MakeTableHdr("Contract calls"),
-            }));
 
+        {
+            json jCols = json::array({
+                MakeTableHdr("Height"),
+                MakeTableHdr("Timestamp"),
+                MakeTableHdr("Hash"),
+                });
+
+#define THE_MACRO(type) \
+            if (TotalsFlags::type & fAbs) OnHdrs_##type##_Abs(jCols); \
+            if (TotalsFlags::type & fRel) OnHdrs_##type##_Rel(jCols);
+
+            ExplorerTotals_All(THE_MACRO)
+#undef THE_MACRO
+
+            jRet.push_back(std::move(jCols));
+        }
         
         Height hMore = 0;
-
-        AggrFormatter af;
-        af.m_Rel = bRel;
-        af.m_Abs = bAbs;
 
         if (hMax && nMax)
         {
@@ -2217,8 +2263,6 @@ private:
                 jRow.push_back(MakeTypeObj("time", s.m_TimeStamp));
                 jRow.push_back(MakeObjBlob(hv));
 
-                af.PushValWithTotal(jRow, NiceDecimal::MakeDifficulty(s.m_ChainWork).m_sz, NiceDecimal::MakeDifficulty(s.m_PoW.m_Difficulty).m_sz);
-
                 bool bDone = false;
 
                 iIdxTots = !iIdxTots;
@@ -2234,29 +2278,12 @@ private:
                 const auto& t1 = pTots[!iIdxTots].m_Totals;
                 const auto& t0 = pTots[iIdxTots].m_Totals;
 
+#define THE_MACRO(type) \
+                if (TotalsFlags::type & fAbs) OnHdrs_##type##_Abs(jRow, t1, s); \
+                if (TotalsFlags::type & fRel) OnHdrs_##type##_Rel(jRow, t1, t0, s);
 
-                // Fees
-                {
-                    auto val = t0.m_Fee;
-                    val.Negate();
-                    val += t1.m_Fee;
-
-                    af.PushValWithTotal(jRow, MakeObjAmount(t1.m_Fee), MakeObjAmount(val));
-                }
-
-                // Txs
-                af.PushValWithTotal(jRow, MakeDecimal(t1.m_Kernels.m_Count).m_sz, MakeDecimalDelta(t1.m_Kernels.m_Count - t0.m_Kernels.m_Count).m_sz);
-                // MW  outputs
-                af.PushValWithTotal(jRow, MakeDecimal(t1.m_MW.m_Outputs.m_Count).m_sz, MakeDecimalDelta(t1.m_MW.m_Outputs.m_Count - t0.m_MW.m_Outputs.m_Count).m_sz);
-                // MW  inputs
-                af.PushValWithTotal(jRow, MakeDecimal(t1.m_MW.m_Inputs.m_Count).m_sz, MakeDecimalDelta(t1.m_MW.m_Inputs.m_Count - t0.m_MW.m_Inputs.m_Count).m_sz);
-                // Shielded outputs
-                af.PushValWithTotal(jRow, MakeDecimal(t1.m_Shielded.m_Outputs).m_sz, MakeDecimalDelta(t1.m_Shielded.m_Outputs - t0.m_Shielded.m_Outputs).m_sz);
-                // Shielded inputs
-                af.PushValWithTotal(jRow, MakeDecimal(t1.m_Shielded.m_Inputs).m_sz, MakeDecimalDelta(t1.m_Shielded.m_Inputs - t0.m_Shielded.m_Inputs).m_sz);
-                // Contracts
-                af.PushValWithTotal(jRow, MakeDecimal(t1.m_Contract.get_Sum()).m_sz, MakeDecimalDelta(t1.m_Contract.get_Sum() - t0.m_Contract.get_Sum()).m_sz);
-
+                ExplorerTotals_All(THE_MACRO)
+#undef THE_MACRO
 
                 jRet.push_back(std::move(jRow));
 
@@ -2289,7 +2316,7 @@ private:
         json jInfo = json::array();
         jInfo.push_back({ MakeTableHdr("Transactions"), MakeDecimal(sd.m_Totals.m_Kernels.m_Count).m_sz });
         jInfo.push_back({ MakeTableHdr("TXOs"), MakeDecimal(sd.m_Totals.m_MW.m_Outputs.m_Count).m_sz });
-        jInfo.push_back({ MakeTableHdr("UTXOs"), MakeDecimal(sd.m_Totals.m_MW.m_Outputs.m_Count - sd.m_Totals.m_MW.m_Inputs.m_Count).m_sz });
+        jInfo.push_back({ MakeTableHdr("UTXOs"), MakeDecimal(sd.m_Totals.m_MW.get_Utxos()).m_sz });
         jInfo.push_back({ MakeTableHdr("Shielded Outs"), MakeDecimal(sd.m_Totals.m_Shielded.m_Outputs).m_sz });
         jInfo.push_back({ MakeTableHdr("Shielded Ins"), MakeDecimal(sd.m_Totals.m_Shielded.m_Inputs).m_sz });
         jInfo.push_back({ MakeTableHdr("Contracts Invoked"), MakeDecimal(sd.m_Totals.m_Contract.get_Sum()).m_sz });
@@ -2306,11 +2333,8 @@ private:
         jInfo.push_back({ MakeTableHdr("Total Emission"), MakeObjAmount(valAmount) });
 
         // size estimation
-        uint64_t nSizeEternal = sd.m_Totals.m_Kernels.m_Size;
-        nSizeEternal += static_cast<uint64_t>(sizeof(Block::SystemState::Sequence::Element)) * (s.m_Height - Rules::HeightGenesis + 1);
-
-        jInfo.push_back({ MakeTableHdr("Size Compressed"), MakeDecimal(nSizeEternal + sd.m_Totals.m_MW.m_Outputs.m_Size - sd.m_Totals.m_MW.m_Inputs.m_Size).m_sz });
-        jInfo.push_back({ MakeTableHdr("Size Archive"), MakeDecimal(nSizeEternal + sd.m_Totals.m_MW.m_Outputs.m_Size + sd.m_Totals.m_MW.m_Inputs.m_Count * sizeof(ECC::Point)).m_sz });
+        jInfo.push_back({ MakeTableHdr("Size Compressed"), MakeDecimal(get_ChainSize(s.m_Height, sd.m_Totals, false)).m_sz });
+        jInfo.push_back({ MakeTableHdr("Size Archive"), MakeDecimal(get_ChainSize(s.m_Height, sd.m_Totals, true)).m_sz });
 
         PrepareTreasureSchedule();
         if (!m_mapTreasury.empty())

--- a/explorer/adapter.h
+++ b/explorer/adapter.h
@@ -21,6 +21,20 @@ namespace beam {
 struct Node;
 using nlohmann::json;
 
+#define ExplorerTotals_All(macro) \
+    macro(Difficulty) \
+    macro(Fee) \
+    macro(Kernels) \
+    macro(MwOutputs) \
+    macro(MwInputs) \
+    macro(MwUtxos) \
+    macro(ShOutputs) \
+    macro(ShInputs) \
+    macro(ContractsActive) \
+    macro(ContractCalls) \
+    macro(SizeArchieve) \
+    macro(SizeCompressed) \
+
 namespace explorer {
 
 /// node->explorer adapter interface
@@ -30,6 +44,19 @@ struct IAdapter {
         Legacy,
         ExplicitType,
         AutoHtml,
+    };
+
+    struct TotalsFlags {
+
+        enum struct Bit {
+#define THE_MACRO(type) type,
+            ExplorerTotals_All(THE_MACRO)
+#undef THE_MACRO
+        };
+
+#define THE_MACRO(type) static const uint32_t type = 1u << static_cast<uint32_t>(Bit::type);
+        ExplorerTotals_All(THE_MACRO)
+#undef THE_MACRO
     };
 
     Mode m_Mode = Mode::Legacy;
@@ -45,7 +72,7 @@ struct IAdapter {
     virtual json get_block(uint64_t height) = 0;
     virtual json get_block_by_kernel(const Blob& key) = 0;
     virtual json get_blocks(uint64_t startHeight, uint64_t n) = 0;
-    virtual json get_hdrs(uint64_t hMax, uint64_t nMax, bool bRel, bool bAbs) = 0;
+    virtual json get_hdrs(uint64_t hMax, uint64_t nMax, uint32_t fAbs, uint32_t fRel) = 0;
     virtual json get_peers() = 0;
 
 #ifdef BEAM_ATOMIC_SWAP_SUPPORT

--- a/explorer/adapter.h
+++ b/explorer/adapter.h
@@ -72,7 +72,7 @@ struct IAdapter {
     virtual json get_block(uint64_t height) = 0;
     virtual json get_block_by_kernel(const Blob& key) = 0;
     virtual json get_blocks(uint64_t startHeight, uint64_t n) = 0;
-    virtual json get_hdrs(uint64_t hMax, uint64_t nMax, uint32_t fAbs, uint32_t fRel) = 0;
+    virtual json get_hdrs(uint64_t hMax, uint64_t nMax, uint64_t dh, uint32_t fAbs, uint32_t fRel) = 0;
     virtual json get_peers() = 0;
 
 #ifdef BEAM_ATOMIC_SWAP_SUPPORT

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -1260,7 +1260,7 @@
 	else if (type == "hdrs")
 	{
 		xmlhttp.onload = DisplayHdrs;
-		xmlhttp.open("GET", urlPrefix +  "hdrs" + urlSuffix + "&nMax=100");
+		xmlhttp.open("GET", urlPrefix +  "hdrs" + urlSuffix + "&nMax=100&cabs=&crel=dfkoOiIC");
 		xmlhttp.send();
 	}
 	else if (type == "contracts")

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -1,9 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
+<!-- WELCOME TO BEAM SMART EXPLORER!
+- This is an interactive web display of the data queried to a Beam explorer node.
+- The IP address of the explorer node can be changed in var 'urlPrefix'.
+- Current version of the file: v0.4
+
+General rules for developement:
+- Let's keep everything in one single standalone file!
+- HTML/JS/CSS must be compatible with Chrome 83 (to allow also being used as a Beam Wallet DApp).
+- Graphics are embedded as SVG or are Unicode symbols.
+- Ideally, JS functions mainly modify classes while most display features are done by CSS.
+- That way, if we disable styling, the data can directly be copy-pasted somewhere else.
+
+The file is organized in four main sections:
+1) All the CSS styling.
+2) Some static HTML (banner, footer, etc.).
+3) Core JS functions to request the node explorer data and parse it into HTML.
+4) Extra JS functions for adjustments, filtering, sorting, etc.
+
+Disclaimer:
+- This is an experimental work-in-progress.
+- It is provided AS-IS, with no guarantees whatsoever.
+-->
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+  <meta name="theme-color" content="#000000">
+  <!-- Simplified Beam logo SVG favicon is URL-encoded (i.e. mainly replacing < > # and spaces) -->
+  <!-- Remark: Such SVG favicon does not seem to be recognized by Safari -->
+  <link rel="icon" href="data:image/svg+xml,%3Csvg%20viewBox='112%2085%20320%20320'%20xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3EBeam%20favicon%3C/title%3E%3Cpath%20d='m424%20371h-304l152-260zm-229-44%2078-135%2078%20135z'%20fill='%230b76ff'%20fill-rule='evenodd'/%3E%3Cpolygon%20points='225%20314%20272%20226%20320%20314'%20fill='%2339fff2'/%3E%3Cpolygon%20points='120%20192%20272%20278%20272%20287%20120%20246'%20fill='%2324c1ff'/%3E%3Cpolygon%20points='424%20167%20272%20278%20272%20287%20424%20274'%20fill='%23fd76fd'/%3E%3C/svg%3E%0A">
+  <title>Beam Smart Explorer</title>
+
+<!-- ------------ SECTION 1 - CSS STYLES ------------ --> 
 <style>
 
 	/* GENERAL ELEMENTS */
@@ -12,18 +41,31 @@
 		font-family: Arial, Helvetica, sans-serif; /* Default fonts */
 	}
 	html {
- 		font-size: 62.5%; /* Since default browser font size is 16px, this sets an easy 1rem = 10px */
+ 		font-size: 62.5%; /* Since default browser font size is generally 16px, this sets an easy '1rem = 10px' */
 	}
 	:root {
  		background: #d0daff; /* Default background color for all pages */
 	}
+	:link { color: #0066CC; } 	/* Default link colors */
+	:visited { color: #3e1a8b; }
+	:link:active, :visited:active { color: #3e1a8b; }
 	p {
 		font-size: 1.6rem;
 		margin: 5px;
 	}
 	ul {
 		font-size: 1.4rem;
-		padding-right: 10px;
+		padding: 0px 10px 0px 15px;
+		text-align: left;
+	}
+	div > ul {
+		padding: 0px 10px 0px 35px;  /* Wide first bullet point level when not in table cells */
+	}
+	td ul {
+		padding: 0px 10px 0px 15px; /* Tight bullet points when inside table cells */
+	}
+	ul li {
+		padding: 2px 0px 0px 2px;
 	}
 	h1 {
 		font-size: 3.2rem;
@@ -33,88 +75,155 @@
 	h2 {
 		font-size: 2.4rem;
 		text-align: left;
-		margin: 20px 0px 15px 0px;
+		margin: 15px 0px 10px 0px;
 	}
-	h3 {
+	h3, h3 a:link, h3 a:visited {
 		font-size: 1.9rem;
 		text-align: left;
 		color: #17204e;
-		margin: 15px 0px 10px 0px;
-	}
-	h3 a {
-		color: #17204e;
+		margin: 10px 0px 15px 0px;
 	}
 	h3::before {
 		content: "\25b8 \00a0"; /* Nice useless decoration ;-) */
 		color: #17204e;
 	}
-	.blockHeight {
-		font-family: monospace;
+	.blockHeight, .blockHeight a {
+		font-family: "Lucida Console", ui-monospace, monospace;
+		font-weight: normal;
 	}
 	.blockTitle {
-		text-decoration: none;
-		font-size: 3rem;
+		white-space: nowrap; /* Don't wrap text */
 	}
-	.blockTitle a {
-		text-decoration: none;
+	.blockTitle .blockHeight {
+		font-weight: bold;
+	}
+	#LinkToBlocksHeaders {
+		display: inline-block;
+	}
+	#LinkToBlocksHeaders a, .olderBlocks a, .newerBlocks a {
+		text-decoration-line:none;
+		color:#0066CC;
+	}
+	#LinkToBlocksHeaders a:hover, .olderBlocks a:hover, .newerBlocks a:hover {
+		color:#003399;
 	}
 	.assetName {
 		color: black;
-		white-space: nowrap; /* Never wrap text */
+		white-space: nowrap; /* Don't wrap text */
 	}
 	.assetName a {
 		color: black; /* Keep links in black */
 	}
 	.metadata {
-		font-family: monospace;
+		font-family: "Lucida Console", ui-monospace, monospace;
+		color: #505050;
 		font-size: 1.2rem;
+		white-space: nowrap; /* To ensure that the symbol stays inline with text */
+	}
+	/* Display full metadata */
+	.metadata .full {
 		display: inline-block; /* Needed to allow setting a max-width */
-		max-width: 100ch; /* Wrap long strings after 100 characters */
+		max-width: 80ch; /* Wrap long strings after 80 characters */
+		white-space: pre-wrap;
 		word-wrap: break-word; /* Allow breaking words to next line */
+		font-family: inherit;
+	}
+	/* Display reduced metadata */
+	.metadata .reduced {
+		display: inline-block; /* Needed to allow setting a max-width */
+		max-width: 45ch; /* Show only the 45 first characters (good enough for AMML tokens!) */
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-family: inherit;
+	}
+	/* The extend symbols are hidden by default in the HTML. We show them only if right after a truncated element */
+	.metadata .reduced + .extend {
+		display: inline; /* Superseed the HTML 'hidden' attribute */
+		visibility: hidden; /* Hide the symbols but maintain their space */
+		cursor: pointer;
+		font-size: 1.8rem;
+		color: grey;
+		vertical-align: text-bottom; /* This is to align correctly the symbol with the text */
+	}
+	/* Display the extend symbols when hovering over the cell or the span containing a truncated text */
+	td:hover .metadata .reduced + .extend, span:hover .metadata .reduced + .extend {
+		visibility: visible;
+	}
+	/* Highlight the symbol when hovering on it */
+	.extend:hover {
+		color: #2c2c2c !important; /* I don't know why !important is needed here... */
 	}
 	.bool {
-		font-family: monospace;
-		font-size: 1.4rem;
+		font-family: "Lucida Console", ui-monospace, monospace;
+		font-size: 1.6rem;
 		color: black;
 	}
 	.bool.yes {
-		color: green; /* True in green */
+		color: green; /* 'True' in green */
 	}
 	.bool.no {
-		color: blue; /* False in blue */
+		color: blue; /* 'False' in blue */
 	}
 	.time {
-		white-space: nowrap; /* Never wrap text */
-		font-size: 1.4rem;
-	}
-	.cid {
-		font-family: monospace;
+		white-space: nowrap; /* Don't wrap text */
 		font-size: 1.2rem;
-		color: black;
+		color: #650000;
+	}
+	.cid, .kernelId, .blob, .commitment {
+		font-family: "Lucida Console", ui-monospace, monospace;
+		font-size: 1.2rem;
+		color: #525252;
+		white-space: nowrap;
+		display: inline;
+		vertical-align: middle;
 	}
 	.cid a {
-		color: black; /* Keep links black */
+		font-family: "Lucida Console", ui-monospace, monospace;
+		font-size: 1.2rem;
+		color: #525252; /* Keep links black */
 		text-decoration-line: underline;
 		text-decoration-color: grey; /* Use a light underline color */
 	}
 	.cidTitle {
-		font-family: monospace;
+		font-family: "Lucida Console", ui-monospace, monospace;
+		font-weight: normal;
 	}
-	.id {
-		font-family: monospace;
-		font-size: 1.2rem;
+	/* Display truncated texts */
+	.truncated {
+		display: inline-block; /* Needed to allow setting a max-width */
+		max-width: 25ch; /* Show only the 25 first characters */
+		overflow: hidden;
+		text-overflow: ellipsis;
+		font-family: inherit;
 	}
-	.blob {
-		font-family: monospace;
-		font-size: 1.2rem;
+	.expanded {
+		font-family: inherit;
 	}
-	.commitment {
-		font-family: monospace;
-		font-size: 1.2rem;
+	/* The extend symbols are hidden by default in the HTML. We show them only if right after a truncated element */
+	.truncated + .expand {
+		display: inline; /* Superseed the HTML 'hidden' attribute */
+		visibility: hidden; /* Hide the symbols but maintain their space */
+		cursor: pointer;
+		font-size: 1.8rem;
+		color: grey;
+		position: relative;
+	}
+	/* Display the expand symbols when hovering over the cell or the list item containing a truncated text */
+	td:hover .truncated + .expand, li:hover > span .truncated + .expand {
+		visibility: visible;
+	}
+	/* Hide the expand symbol in the special case of a text with link (just to avoid confusion about the effect of clicking) */
+	.truncated.withLink:hover + .expand {
+		visibility: hidden;
+	}
+	/* Highlight the symbol when hovering on it */
+	.expand:hover {
+		color: #2c2c2c;
 	}
 	.amount {
-		font-family: monospace;
-		font-size: 1.7rem;
+		font-family: "Lucida Console", ui-monospace, monospace;
+		font-size: 1.4rem;
 		color: darkcyan;
 	}
 	.amount.pos {
@@ -124,7 +233,7 @@
 		color: red; /* Negative values in red */
 	}
 	.th {
-		/* Not sure yet how to use this class (these "headers" can appear in rows or in columns)... */
+		/* This class is a "header" type from the node explorer data */
 	}
 	.more {
 		font-weight: bold;
@@ -146,21 +255,21 @@
 		border-collapse: collapse; /* Join table and cell borders as one single line */
 		padding: 5px; /* Add a small padding */
 	}
-	table thead > tr {
-		background-color: #b8bbd8; /* Background color for table headers already declared as such ("thead" tag) */
+	table thead > tr th {
+		background-color: #b8bbd8; /* Background color for table header cells declared as such ("thead" tag) */
 	}
 	th {
-		white-space: nowrap; /* Never wrap header text */
+		white-space: nowrap; /* Don't wrap header text */
 	}
 	.tableGeneric {
 		/* Nothing special */
 	}
 	.tableUTXO, .tableKernels {
-		min-width: 100ch; /* Just to keep them balanced (inputs, outputs, kernels) */
+		min-width: 50ch; /* Just to keep them visually balanced (inputs, outputs, kernels) */
 		margin: 5px;
 	}
 	.tableSummary, .tableTotals {
-		min-width: 70ch; /* Just to keep them balanced */
+		min-width: 70ch; /* Just to keep them visually balanced */
 	}
 	.tableOwned_compact, .tableOwned_full {
 		width: 100%; /* Occupy full width of the column they appear in */
@@ -171,15 +280,21 @@
 	.tableContracts, .tableAssetHistory, .tableAssets, .tableCallHistory {
 		/* Nothing special */
 	}
+	.contractCall {
+		border: 3px solid #555fb8; /* Group multiple contract calls within a thick border */
+	}
+	.mainCall, .subCall {
+		text-align: center;
+	}
 	.divTableStatus, .divTableBlocks {
-		/* Dirty hack added to wrap and detect some special types of generic tables... */
+		/* These div are just a dirty hack added to wrap and identify some special types of generic tables... */
 	}
 	/* Alternate row colors (...although the colors get mixed up when the table is filtered!) */
 	table tbody > tr:nth-child(odd) { background-color: #fff; }
 	table tbody > tr:nth-child(even) { background-color: #eee; }
 
-	/* TITLE BANNER */
-	.banner {
+	/* TITLE BANNER AND FOOTER */
+	#Banner {
 		width: 97vw;
 		display: table;
 		background-color: #a7acd9;
@@ -191,22 +306,36 @@
 		display: table-cell;
 		vertical-align: middle;
 		text-align: left;
-		min-height: 60px;
-		min-width: 60px;
+		min-height: 50px;
+		min-width: 50px;
 	}
-	#BeamTitle {
+	#BannerCenter{
 		display: table-cell;
 		vertical-align: middle;
 		text-align: center;
-		font-size: 2.8rem;
-		color: #17204e;
 		width: 100%;
 		white-space: nowrap; /* Never wrap text */
 		padding: 5px 10px 5px 10px;
 	}
+	#BeamTitle {
+		font-size: 2.4rem;
+		color: #17204e;
+		margin: 0px 0px 5px 0px;
+	}
 	#Version {
 		font-size: 1rem;
 		color: #525252;
+	}
+	#Menu {
+		font-size: 1.5rem;
+		color: #17204e;
+	}
+	.menuItem a {
+		color: #2d3799; /* No change of color when followed */
+	}
+	.menuSeparator {
+		color: #17204e;
+		padding: 0px 5px 0px 5px;
 	}
 	#Navigation {
 		display: table-cell;
@@ -215,16 +344,23 @@
 		font-size: 2rem;
 		color: #525252;
 		padding: 0px 10px 0px 10px;
+		line-height: 1; /* Without units it's a number of lines */
 	}
 	#Navigation a {
 		color: #525252;
 		text-decoration-line: none;
 	}
-	#TopButton {
-		display: none; /* Hidden by default */
-		position: fixed; /* Fixed/sticky position */
-		bottom: 10px; /* Bottom of the page */
-		right: 10px; /* Right side of the page */
+	#Reload {
+		font-weight: bold;
+	}
+	#Back, #ExpandAll {
+		/* Nothing special */
+	}
+	#Reload:hover, #Back:hover, #ExpandAll:hover {
+		color: #2c2c2c;
+	}
+	#TopButton, #BottomButton {
+		position: fixed; /* Fixed position */
 		z-index: 99; /* Make sure it does not overlap */
 		cursor: pointer; /* Mouse pointer on hover */
 		border: none; /* Remove borders */
@@ -237,7 +373,17 @@
 		color: white; /* Text color */
 		padding: 10px; /* Some padding */
 	}
-	#TopButton:hover {
+	#TopButton {
+		display: none; /* Hidden by default */
+		bottom: 50px; /* Bottom of the page */
+		right: 10px; /* Right side of the page */
+	}
+	#BottomButton {
+		display: block; /* Shown by default */
+		bottom: 10px; /* Bottom of the page */
+		right: 10px; /* Right side of the page */
+	}
+	#TopButton:hover, #BottomButton:hover {
 		opacity: 0.9; /* Less transparent on hover */
 		background-color: rgb(0,0,0,0.4); /* Background with more transparency */
 	}
@@ -248,7 +394,7 @@
 		color: #17204e;
 		text-decoration: none;
 		font-weight: bold;
-		white-space: nowrap; /* Never wrap text */
+		white-space: nowrap; /* Don't wrap text */
 		padding: 20px 5px 0px 5px;
 	}
 	.footer::before {
@@ -261,6 +407,7 @@
 	}
 
 	/* COLLAPSIBLE BLOCKS */
+	/* Remark: We use the 'checkbox hack' to make collapsibles 100% CSS */
 	.collapsible {
 		display: block; 
 		width: fit-content; /* Will have the width of its full content */
@@ -323,7 +470,7 @@
 	.collapsible-content {
 		display: block;
 		width: 100%;
-		height: 0px; /* Hide by collapsing its height only (thus maitaining its horizontal space) */
+		height: 0px; /* Hide by collapsing its height only (thus maintaining its horizontal space) */
 		overflow: hidden;
 		background-color: white;
 	}
@@ -333,32 +480,51 @@
 	}
 	.collapsible-checkbox:checked + .collapsible-label + .collapsible-content {
 		height: unset;  /* Show content's full height */
+		overflow: visible;
 		border: 0.5px solid #777ebc; /* Add a thin border */
 	}
 	.collapsible-checkbox:checked + .collapsible-label + .collapsible-content.small {
 		display: block; /* Show content */
+		overflow: visible;
 		border: none; /* No border for small collapsibles */
 	}
 
-	/* SORT AND SEARCH HEADERS IN TABLES
-	/* Header row when filters are off */
-	.filtersOff, .filtersNot {
-		background-color: #b8bbd8 !important; /* Background for all table headers */
-	}
-	.filtersOff:hover {
-		cursor: pointer; /* Change mouse to pointer to show it's clickable */
-		background-color: #9ca2d2 !important; /* Background for table header */
-	}
-	/* Header row when filters are on */
-	.filtersOn {
-		background-color: #9ca2d2 !important; /* Background for table header */
-	}
-	.filtersOff th, .filtersOff td, .filtersOn th, .filtersOn td, .filtersNot th, .filtersNot td, .headerCell {
+	/* SORT AND SEARCH HEADERS IN TABLES */
+	/* General for all headers */
+	.filtersOff th, .filtersOn th, .filtersNot th, .headerCell, .headerRow {
 		text-align: center;
 		white-space: nowrap; /* Don't wrap header text */
 		font-weight: bold;
 	}
-	
+	/* Add placeholders for sorting indicators */
+	.filtersOff th::before {
+		content: '\21c5 \00a0';
+		visibility: hidden;
+	}
+	/* Force same min column width as when filters are on */
+	.filtersOff th {
+		min-width: 5ch;
+	}
+	/* Headers when filters are off */
+	.filtersOff th {
+		background-color: #b8bbd8;
+	}
+	.filtersOff:hover th {
+		cursor: pointer; /* Change mouse to pointer to show it's clickable */
+		background-color: #9ca2d2;
+	}
+	/* Headers when filters are on */
+	.filtersOn th {
+		background-color: #9ca2d2;
+	}
+	/* Make header rows sticky to the top of the window */
+	/* Remark: On Chrome 83, sticky only works on 'th' (not on 'thead' or 'tr') */
+	.filtersOff th, .filtersOn th {
+		position: sticky;
+		top: 0;
+		z-index: 10;
+	}
+
 	/* SORT OPTIONS IN HEADERS */
 	.sortable {
 		cursor: pointer; /* Change mouse pointer to show it's clickable */
@@ -368,59 +534,113 @@
 		content: '\21c5 \00a0'; /* Symbol when not sorted */
 		color: #666;
 	}
+	.sortable:hover::before { /* Highlight symbol on hover */
+		color: #e7e7e7;
+	}
 	.sortable.asc::before {
-		content: '\25bc \00a0'; /* Symbol when sorted ascending */
+		content: '\25b2 \00a0'; /* Symbol when sorted ascending */
 		color: #e7e7e7;
 	}
 	.sortable.desc::before {
-		content: '\25b2 \00a0'; /* Symbol when sorted descending */
+		content: '\25bc \00a0'; /* Symbol when sorted descending */
 		color: #e7e7e7;
 	}
 
 	/* SEARCH OPTIONS IN HEADERS */
 	.searchable {
+		/* Nothing special */
+	}
+	.search {
 		visibility: hidden; /* Search fields are hidden by default */
-		width: 90%;
+		display: inline-block;
+		width: 95%;
 		max-width: 20ch;
 		min-width: 5ch;
 		border-radius: 0.25em; /* Slightly round corners */
-		border: 1px solid #ddd; /* White border */
+		border: 1px solid #555; /* Dark border */
 		background-color: #afb3d8;
 		padding: 0.25ch 1ch 0.25ch 1ch ; /* Internal padding */
 	}
 	/* Search fields on hover */
-	.headerCell:hover .searchable {
+	.headerCell:hover .search {
 		visibility: visible; /* Make it appear when hover */
 	}
 	/* Search fields with content */
-	.searchable:not(:placeholder-shown) {
+	.search:not(:placeholder-shown) {
 		visibility: visible; /* Keep it visible */
-		max-width: 90%; /* Extend to full width */
+		max-width: 95%; /* Extend to full width */
 		background-color: #b8bbd8; /* Use a lighter background */
+		border: 1px solid #ddd; /* White border */
 	}
 	/* Search fields on focus */
-	.searchable:focus {
+	.search:focus {
 		visibility: visible; /* Keep it visible */
-		max-width: 90%; /* Extend to full width */
+		max-width: 95%; /* Extend to full width */
 		outline: none; /* Avoid the browser default focus outline */
-		border: 1px solid #555; /* Darker border */
+		border: 1px solid #ddd; /* White border */
 	}
 	
 </style>
+
 </head>
-
 <body>
+<!-- ------------ SECTION 2 - STATIC HTML ------------ --> 
 
-<p id="my_content">Loading...</p>
+	<!-- Fixed banner on all pages -->
+	<div id="Banner">
+		<span id="BeamLogo">
+			<!-- Clicking on the logo sends back to the main page -->
+			<a href='?' title='Main page'>
+				<!-- An SVG version of the BEAM logo -->
+				<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' height='50' width='50' viewBox='42 42 460 460'><defs><style>.cls-1 {fill: #0b1624;} .cls-2 {fill: #24c1ff;} .cls-3 {fill: #0b76ff;} .cls-4 {fill: #39fff2;} .cls-5 {fill: #00e2c2;} .cls-6 {fill: url(#Ray1_gradient);} .cls-7 {fill: url(#Ray2_gradient);} .cls-8 {fill: url(#Ray3_gradient);} .cls-9 {fill: url(#Ray4_gradient);} </style><linearGradient id='Ray1_gradient' x1='-24.6' y1='683.51' x2='-23.57' y2='683.51' gradientTransform='matrix(98, 0, 0, -47, 2497.75, 32364.11)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#fff' stop-opacity='0'/><stop offset='1' stop-color='#fff'/></linearGradient><linearGradient id='Ray2_gradient' x1='-28.7' y1='703.17' x2='-27.72' y2='703.17' gradientTransform='matrix(-98, 0, 0, 26, -2353.25, -18019.72)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#9d6eff' stop-opacity='0'/><stop offset='1' stop-color='#a18cff'/></linearGradient><linearGradient id='Ray3_gradient' x1='-28.69' y1='682.8' x2='-27.57' y2='682.8' gradientTransform='translate(-2353.25 29603.78) rotate(180) scale(98 43)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#ae60d6' stop-opacity='0'/><stop offset='1' stop-color='#ab38e6'/></linearGradient><linearGradient id='Ray4_gradient' x1='-28.68' y1='685.09' x2='-27.47' y2='685.09' gradientTransform='translate(-2353.25 41328.94) rotate(180) scale(98 60)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#fd76fd' stop-opacity='0'/><stop offset='1' stop-color='#ff51ff'/></linearGradient></defs><g id='logo_in_circle' data-name='logo in circle'><circle id='circle' class='cls-1' cx='272' cy='272' r='230'/><g id='logo'><path id='Triangle-left' class='cls-2' d='M272.25,327.21H194.72l77.5-135V110.45L120.31,370.64H272.25Z'/><path id='Triangle-right' class='cls-3' d='M272.25,327.21h77.53l-77.5-135V110.45L424.19,370.64H272.25Z'/><polygon id='Triangle-small-left' class='cls-4' points='272.25 226.3 272.25 313.57 224.77 313.67 272.25 226.3'/><polygon id='Triangle-small-right' class='cls-5' points='272.25 226.3 272.25 313.57 319.73 313.67 272.25 226.3'/><polygon id='Ray1-left' class='cls-6' points='86.13 191.81 272.25 277.83 272.25 286.83 86.13 246.1 86.13 191.81'/><polygon id='Ray2-right-low' class='cls-7' points='458.75 274.33 272.25 286.83 272.25 283.83 458.75 238.5 458.75 274.33'/><polygon id='Ray3-right-mid' class='cls-8' points='458.75 202.67 272.25 280.83 272.25 283.83 458.75 238.5 458.75 202.67'/><polygon id='Ray4-right-top' class='cls-9' points='458.75 166.83 272.25 277.83 272.25 280.83 458.75 202.67 458.75 166.83'/></g></g></svg>
+			</a>
+		</span>
+		<span id="BannerCenter">
+			<h1 id="BeamTitle">Beam Smart Explorer <span id='Version'>v0.4</span></h1>
+			<div id="Menu">
+				<!-- Main explorer menu -->
+				<span class="menuItem"><a href="javascript:window.location.href=window.location.pathname + '?type=hdrs';" title="List of recent Block Headers">Block Headers</a></span>
+				<span class="menuSeparator"> | </span>
+				<span class="menuItem"><a href="javascript:window.location.href=window.location.pathname + '?type=assets';" title="List of current Confidential Assets">Confidential Assets</a></span>
+				<span class="menuSeparator"> | </span>
+				<span class="menuItem"><a href="javascript:window.location.href=window.location.pathname + '?type=contracts';" title="List of currently deployed Smart Contracts">Smart Contracts</a></span>
+			</div>
+		</span>
+		<!-- Banner symbols for special functions -->
+		<span id="Navigation">
+			<a id="Reload" href="" title="Reload">&orarr;</a>
+			<br><a id="Back" href="javascript:history.back();" title="Back">&#11013;</a> <!-- &#129048; was better but is apparently not recognized by Safari... -->
+			<br><a id="ExpandAll" href="javascript:expandEverything();" title="Expand everything">&#128065;</a>
+		</span>
+	</div>
 
+	<!-- Floating buttons to scroll up and down -->
+	<div>
+		<button onclick='topFunction();' id='TopButton' title='Top'>&#9650;</button>
+		<button onclick='bottomFunction();' id='BottomButton' title='Bottom'>&#9660;</button>
+	</div>
+
+	<!-- Main content area (will be replaced through Javascript) -->
+	<p id="my_content">
+		<br><br>Loading...<br><br>
+	</p>
+
+	<!-- Fixed footer on all pages -->
+	<div class='footer'><a href='https://www.beam.mw'>www.beam.mw</a></div>
+
+	<!-- No JavaScript warning -->
+	<noscript>You need to enable JavaScript to run this app.</noscript>
+
+
+<!-- ------------ SECTION 3 - CORE JS FUNCTIONS ------------ --> 
 <script>
 
 	function MakeRef(link, text)
 	{
-		return "<a href=\"" + link + "\">" + text + "</a>";
+		return "<a href='" + link + "'>" + text + "</a>";
 	}
 
-	function UrlSelf(type, extra)
+	function UrlSelf(type, extra="")
 	{
 		return window.location.pathname + "?type=" + type + extra;
 	}
@@ -442,7 +662,7 @@
 
 	function MakeCellRA(text, styles)
 	{
-		return MakeCellEx(text, " align=\"right\"");
+		return MakeCellEx(text, " align='right'");
 	}
 	
 	function MakeAmountClr(amount)
@@ -462,6 +682,11 @@
 		return "<span class='" + className + "'>" + txt + "</span>";
 	}
 	
+	function AddClassEx(txt,className,other)
+	{
+		return "<span class='" + className + "' " + other + ">" + txt + "</span>";
+	}
+
 	function UrlBlock(h)
 	{
 		return UrlSelfWithID("block", h, "");
@@ -486,7 +711,7 @@
 	
 	function MakeCid(cid)
 	{
-		return AddClass(MakeRef(UrlSelfWithID("contract", cid, ""), cid), "cid");
+		return AddClassEx(MakeRef(UrlSelfWithID("contract", cid, ""), cid), "cid", "title='" + cid + "'");
 	}
 		
 	function MakeFundsTbl(jFunds)
@@ -496,7 +721,7 @@
 
 		let text = "";
 
-		// Make collapsible and add some headers if more than a few lines
+		// Make collapsible and add some headers if more than a few rows
 		let maxRows = 5;
 		if (jFunds.length < maxRows) {
 			text += "<table class='tableFunds_compact'>";
@@ -539,7 +764,7 @@
 				
 				for (let iCol = 0; iCol < jRow.length; iCol++)
 				{
-					text += "<td align=\"right\">";
+					text += "<td align='right'>";
 					text += Obj2Html(jRow[iCol]);
 					text += "</td>";
 				}
@@ -547,7 +772,6 @@
 				text += "</tr>";
 			}
 		}
-		
 		return text;
 	}
 	
@@ -574,7 +798,6 @@
 			text += "</table>";
 			
 			return text;
-
 		}
 		
 		if (obj.type == "aid")
@@ -584,7 +807,7 @@
 			return AddClass(MakeBlock(obj.value), "blockHeight");
 
 		if (obj.type == "blob")
-			return AddClass(obj.value, "blob");
+			return AddClassEx(obj.value, "blob", "title='" + obj.value + "'");
 
 		if (obj.type == "bool")
 			return (obj.value > 0) ? AddClass("yes", "bool yes") : AddClass("no", "bool no");
@@ -618,7 +841,6 @@
 			
 			txt += "</ul>";
 			return txt;
-		
 		}
 
 		if (typeof obj == 'object')
@@ -638,42 +860,32 @@
 			txt += "</ul>";
 			return txt;
 		}
+
+		// If data is a text string starting with "STD:" (i.e. it's an asset description), then we type it as "metadata"
+		if (typeof obj === "string" && obj.startsWith("STD:"))
+		{
+			return AddClass(obj, "metadata");
+		}
 			
 		return obj;
 	}
 	
 	function SetContent(text)
 	{
-		// Fixed banner on all pages
-		let banner = "\
-			<div class='banner'>\n\
-				<span id='BeamLogo'>\n\
-					<a href='" + window.location.pathname + "' title='Main'>\n\
-						<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='42 42 460 460'><!-- A variaion of the BEAM logo --><defs><style>.cls-1 {fill: #0b1624;} .cls-2 {fill: #24c1ff;} .cls-3 {fill: #0b76ff;} .cls-4 {fill: #39fff2;} .cls-5 {fill: #00e2c2;} .cls-6 {fill: url(#Ray1_gradient);} .cls-7 {fill: url(#Ray2_gradient);} .cls-8 {fill: url(#Ray3_gradient);} .cls-9 {fill: url(#Ray4_gradient);} </style><linearGradient id='Ray1_gradient' x1='-24.6' y1='683.51' x2='-23.57' y2='683.51' gradientTransform='matrix(98, 0, 0, -47, 2497.75, 32364.11)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#fff' stop-opacity='0'/><stop offset='1' stop-color='#fff'/></linearGradient><linearGradient id='Ray2_gradient' x1='-28.7' y1='703.17' x2='-27.72' y2='703.17' gradientTransform='matrix(-98, 0, 0, 26, -2353.25, -18019.72)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#9d6eff' stop-opacity='0'/><stop offset='1' stop-color='#a18cff'/></linearGradient><linearGradient id='Ray3_gradient' x1='-28.69' y1='682.8' x2='-27.57' y2='682.8' gradientTransform='translate(-2353.25 29603.78) rotate(180) scale(98 43)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#ae60d6' stop-opacity='0'/><stop offset='1' stop-color='#ab38e6'/></linearGradient><linearGradient id='Ray4_gradient' x1='-28.68' y1='685.09' x2='-27.47' y2='685.09' gradientTransform='translate(-2353.25 41328.94) rotate(180) scale(98 60)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#fd76fd' stop-opacity='0'/><stop offset='1' stop-color='#ff51ff'/></linearGradient></defs><g id='logo_in_circle' data-name='logo in circle'><circle id='circle' class='cls-1' cx='272' cy='272' r='230'/><g id='logo'><path id='Triangle-left' class='cls-2' d='M272.25,327.21H194.72l77.5-135V110.45L120.31,370.64H272.25Z'/><path id='Triangle-right' class='cls-3' d='M272.25,327.21h77.53l-77.5-135V110.45L424.19,370.64H272.25Z'/><polygon id='Triangle-small-left' class='cls-4' points='272.25 226.3 272.25 313.57 224.77 313.67 272.25 226.3'/><polygon id='Triangle-small-right' class='cls-5' points='272.25 226.3 272.25 313.57 319.73 313.67 272.25 226.3'/><polygon id='Ray1-left' class='cls-6' points='86.13 191.81 272.25 277.83 272.25 286.83 86.13 246.1 86.13 191.81'/><polygon id='Ray2-right-low' class='cls-7' points='458.75 274.33 272.25 286.83 272.25 283.83 458.75 238.5 458.75 274.33'/><polygon id='Ray3-right-mid' class='cls-8' points='458.75 202.67 272.25 280.83 272.25 283.83 458.75 238.5 458.75 202.67'/><polygon id='Ray4-right-top' class='cls-9' points='458.75 166.83 272.25 277.83 272.25 280.83 458.75 202.67 458.75 166.83'/></g></g></svg>\n\
-					</a>\n\
-				</span>\n\
-				<h1 id='BeamTitle'>Beam Smart Explorer <span id='Version'>v0.3</span></h1>\n\
-				<span id='Navigation'><a href='' title='Reload'>&orarr;</a><br><a href='javascript:history.back();' title='Back'>&larr;</a></span>\n\
-			</div>\n\
-			<div>\n\
-				<button onclick='topFunction();'' id='TopButton' title='Top'>&#9650;</button>\n\
-			</div>";
+		document.getElementById("my_content").innerHTML = text;
 
-		let footer = "<div class='footer'><a href='https://www.beam.mw'>www.beam.mw</a></div>";
-
-		document.getElementById("my_content").innerHTML = banner + text + footer;
-		
-		// Add option for adding filters to the first row of long tables
+		// Add truncate/expand options to all text of type hash, cid, metadata, etc.
+		addExpandOptions();
+		// Include options for adding filters to the first row of long tables
 		addFilterOption();
 	}
 	
 	let g_CurrentID = "";
 
-
 	function DisplayContracts()
 	{
 		let text = "\
-		<h2>Deployed contracts</h2>\n\
+		<h2>Deployed Smart Contracts</h2>\n\
 		<table class='tableContracts'>\n\
 			<thead><tr>\n\
 				<th>Cid</th>\n\
@@ -705,7 +917,7 @@
 			const jOwned = jRow[4]["value"];
 			if (jOwned)
 			{
-				// Make collapsible and add some headers if more than a few lines
+				// Make collapsible and add some headers if more than a few rows
 				let maxRows = 5;
 				if (jOwned.length < maxRows) {
 					text += "<table class='tableOwned_compact'>";
@@ -723,11 +935,9 @@
 				{
 					const jFR = jOwned[iF];
 					text += "<tr>";
-					text += MakeCellEx(MakeAsset(jFR[0]["value"]), " style=\"width:10%\"");
-					text += MakeCell(MakeCollapsibleBegin("[description]", "", "small")
-									+ AddClass(jFR[1], "metadata")
-									+ MakeCollapsibleEnd());
-					text += MakeCellAmount(jFR[2]["value"], " style=\"width:40%\"");
+					text += MakeCellEx(MakeAsset(jFR[0]["value"]), " style='width:10%'");
+					text += MakeCell(AddClass(jFR[1], "metadata"));
+					text += MakeCellAmount(jFR[2]["value"], " style='width:40%'");
 					text += "</tr>"
 				}
 				text += "</table>";
@@ -741,16 +951,21 @@
 		
 		}
 		
-	
 		text += "</table>"    
 		SetContent(text);
 	}
 
-
 	function DisplayAssetHistory()
 	{
-		let text = "\
-		<h2>History of Asset " + g_CurrentID + "</h2>\n\
+		const jData = JSON.parse(this.responseText);
+		const jTblObj = jData["Asset history"];
+		const jTbl = jTblObj["value"];
+		
+		let text = "<h2>\n"
+		text += "History of Asset " + g_CurrentID;
+		text += "</h2>\n"
+
+		text += "\
 		<table class='tableAssetHistory'>\n\
 			<thead><tr>\n\
 				<th>Height</th>\n\
@@ -761,11 +976,7 @@
 			</tr></thead>\n\
 		";
 
-		const jData = JSON.parse(this.responseText);
-		const jTblObj = jData["Asset history"];
-		const jTbl = jTblObj["value"];
-		
-		// skip 1st row
+		// Skip first row
 		for (let iRow = 1; iRow < jTbl.length; iRow++)
 		{
 			const jRow = jTbl[iRow];
@@ -779,9 +990,9 @@
 			text += "</tr>";
 		}
 		
-	
-		text += "</table>"    
-		text += MakeMoreLink(jTblObj);
+		text += "</table>"
+		text +="<p>" + AddClassEx(MakeRef(MakeLinkToOlderBlocks(jTblObj), "Previous blocks..."),"more","title='Previous blocks'") + "</p>";
+
 		SetContent(text);
 	}
 	
@@ -808,7 +1019,7 @@
 			let jRow = jTbl[i];
 			text += "<tr>";
 
-			text += MakeCell(AddClass(jRow["commitment"], "commitment"));
+			text += MakeCell(AddClassEx(jRow["commitment"], "commitment", " title='" + jRow["commitment"] + "'"));
 			delete jRow.commitment;
 	
 			let j = jRow[isInp ? "height" : "spent"];
@@ -853,7 +1064,6 @@
 				delete jRow.Value;
 			}
 
-			//text += MakeCell(txtExtra + Obj2Html(jRow));
 			text += MakeCell(txtExtra);
 			
 			text += "</tr>";
@@ -878,7 +1088,7 @@
 
 		let jTbl = j["value"];
 		
-		// skip 1st row
+		// Skip first row
 		for (let iRow = 1; iRow < jTbl.length; iRow++)
 		{
 			const jRow = jTbl[iRow];
@@ -893,7 +1103,6 @@
 			
 			text += "</tr>";
 		}
-		
 	
 		text += "</table>"
 		return text;
@@ -901,7 +1110,7 @@
 
 	function MakeCAs(h)
 	{
-		return "<h3>" + MakeRef(UrlSelfWithID("assets", h, ""), "Confidential Assets") + "</h3>";
+		return "<h3>" + MakeRef(UrlSelfWithID("assets", h, ""), "Confidential Assets at this block height") + "</h3>";
 	}
 
 	function DisplayBlock()
@@ -909,9 +1118,9 @@
 		let text = "";
 		
 		text += "<h2 class='blockTitle'>";
-		if (g_CurrentID > 0)
-		{
-			text += MakeRef(UrlBlock(g_CurrentID - 1), "&larr;");
+		if (g_CurrentID > 0) {
+			text += "<span id='LinkToBlocksHeaders'><a href='" + UrlSelf("hdrs", "&hMax=" + g_CurrentID) + "' title='List of blocks below this one'>&#128463;</a></span> ";
+			text += AddClassEx(MakeRef(UrlBlock(g_CurrentID - 1), "&#10094;"),"olderBlocks","title='Previous block'");
 			text += " ";
 			text += "Block " + AddClass(g_CurrentID, "blockHeight");
 		}
@@ -919,7 +1128,7 @@
 			text += "Treasury";
 
 		text += " ";
-		text += MakeRef(UrlBlock(g_CurrentID - 1 + 2), "&rarr;");
+		text += AddClassEx(MakeRef(UrlBlock(g_CurrentID - 1 + 2), "&#10095;"),"newerBlocks","title='Next block'");
 		text += "</h2>"
 
 		const jData = JSON.parse(this.responseText);
@@ -953,9 +1162,7 @@
 		let jTbl = jData["kernels"];
 		if (jTbl)
 		{
-		
 			text += "<h3>Kernels</h3>\n";
-
 			text += "\
 			<table class='tableKernels'>\n\
 				<thead><tr>\n\
@@ -966,13 +1173,12 @@
 				</tr></thead>\n\
 			";
 
-		
 			for (let i = 0; i < jTbl.length; i++)
 			{
 				let jRow = jTbl[i];
 				text += "<tr>";
 
-				text += MakeCell(AddClass(jRow["id"], "id"));
+				text += MakeCell(AddClassEx(jRow["id"], "kernelId", " title='" + jRow["id"] + "'"));
 				text += MakeCellRA(Obj2Html(jRow["fee"]));
 			
 				let txtH = "";
@@ -1005,7 +1211,6 @@
 				text += "</tr>";
 			}
 			text += "</table>"
-
 		}
 
 		text += MakeCollapsibleEnd();
@@ -1047,8 +1252,6 @@
 		return retVal;
 	}
 
-	//var rowHeight = ""; // Used to remember and repeat the latest row height (and avoid using rowspans in the CallHistoryAddRow function).
-	//var rowNbr; // Used to number the subsequent rows.
 	function CallHistoryAddRow(jRow, depth, numRows)
 	{
 		let text = "";
@@ -1063,24 +1266,19 @@
 				if (!i)
 					depth++;
 			}
-			
 		}
 		else
 		{
 			text += "<tr>";
 			
-			//if (depth == 0)
-			//	text += MakeCellEx(MakeBlock(jRow[0]), " rowSpan=" + numRows);
-
-			// We replace here the use of "rowspan" with a simple repetition to allow filtering and sorting
+			// We use empty cells for subsequent contract calls at same height
+			// (all these rows are kept together within a dedicated tbody).
 			if (depth == 0) {
-				text += MakeCell(MakeBlock(jRow[0]));
-				//rowHeight = jRow[0]; // Save it to repeat it on subsequent rows with same height
-				//rowNbr = 1; // Start numbering subsequent rows
+				// Display block height for main contract call
+				text += MakeCellEx(MakeBlock(jRow[0])," class='mainCall'");
 			} else {
-				//rowNbr++;
-				//text += MakeCell(MakeBlock(rowHeight) + "&nbsp;(" + rowNbr + ")");
-				text += MakeCell("");
+				// Use an empty cell for subsequent contract calls
+				text += MakeCellEx(""," class='subCall'");
 			}
 
 			text += MakeCell(Obj2Html(jRow[1]));
@@ -1114,8 +1312,9 @@
 		return "</div></div>\n";
 	}
 	
-	function MakeMoreLink(jTblObj)
+	function MakeLinkToOlderBlocks(jTblObj) // Link to go backwards one page of older blocks
 	{
+		// This function uses the information given by the node explorer to move pages backwards
 		const jMore = jTblObj["more"];
 		if (!jMore)
 			return "";
@@ -1126,42 +1325,69 @@
 		for (let key in jMore)
 			args.set(key, jMore[key]);
 			
-		return "<p class='more'>" + MakeRef(urlObj.pathname + "?" + args, "More...") + "</p>";
+		return urlObj.pathname + "?" + args;
+	}
+
+	function MakeLinkToNewerBlocks(jTblObj) // Link to go forward one page of newer blocks
+	{
+		// Temporary hack:
+		// The node explorer does not provide (yet?) parameters to move pages forward.
+		// Until then, we use the parameter given to go backwards and simply add twice nMax to it.
+		// This is imperfect, temporary, and -of course- only works for the Block Headers page...
+		const jMore = jTblObj["more"];
+		if (!jMore)
+			return "";
+			
+		let urlObj = new URL(document.location);
+		let args = urlObj.searchParams;
+		
+		for (let key in jMore) {
+			if (key == "hMax") {
+				args.set(key, jMore[key] - 0 + nMax*2);
+			} else {
+				args.set(key, jMore[key]);
+			}
+		}
+			
+		return urlObj.pathname + "?" + args;
 	}
 
 	function DisplayContractState()
 	{
-		let text = "\
-		<h2>Contract " + AddClass(g_CurrentID, "cidTitle") + "</h2>\n";
-
-	text += MakeCollapsibleBegin("Call history") + "\
-	<table class='tableCallHistory'>\n\
-		<thead><tr>\n\
-			<th>Height</th>\n\
-			<th>Cid</th>\n\
-			<th>Kind</th>\n\
-			<th>Method</th>\n\
-			<th>Arguments</th>\n\
-			<th>Funds</th>\n\
-			<th>Emisison</th>\n\
-			<th>Keys</th>\n\
-		</tr></thead>\n\
-	";
-
 		const jData = JSON.parse(this.responseText);
 		const jTblObj = jData["Calls history"];
 		const jTbl = jTblObj["value"];
 		
-		// skip 1st row
+		let text = "<h2>\n"
+		text += "Contract " + AddClass(g_CurrentID, "cidTitle");
+		text += "</h2>\n"
+
+		text += MakeCollapsibleBegin("Call history") + "\
+		<table class='tableCallHistory'>\n\
+			<thead><tr>\n\
+				<th>Height</th>\n\
+				<th>Cid</th>\n\
+				<th>Kind</th>\n\
+				<th>Method</th>\n\
+				<th>Arguments</th>\n\
+				<th>Funds</th>\n\
+				<th>Emisison</th>\n\
+				<th>Keys</th>\n\
+			</tr></thead>\n\
+		";
+
+		// Skip first row
 		for (let iRow = 1; iRow < jTbl.length; iRow++)
 		{
-			//text += "<tr><td colspan=99></td></tr>";
+			// Multiple contract calls are grouped in dedicated tbodies (HTML tables can have multiple tbodies!)
+			text += "<tbody class='contractCall'>"
 			text += CallHistoryAddRow(jTbl[iRow], 0, get_CallRows(jTbl[iRow]));
+			text += "</tbody>"
 		}
 	
 		text += "</table>";
-		text += MakeMoreLink(jTblObj);
-
+		text +="<p>" + AddClassEx(MakeRef(MakeLinkToOlderBlocks(jTblObj), "Previous blocks..."),"more","title='Previous blocks'") + "</p>";
+		
 		text += MakeCollapsibleEnd();
 
 		text += MakeCollapsibleBegin("State");
@@ -1186,12 +1412,19 @@
 	function DisplayHdrs()
 	{
 		const jData = JSON.parse(this.responseText);
-	
-		let text = "<h2>Block headers</h2>";
+		//const jTbl = jData["value"];
+
+		let text = "<h2>\n"
+		// Arrows &#129092; and &#129094; were better but apparently not recognized by Safari... :-(
+		text += AddClassEx(MakeRef(MakeLinkToOlderBlocks(jData), "&#10094;&nbsp;"),"olderBlocks","title='Previous blocks'");
+		text += "Block headers";
+		text += AddClassEx(MakeRef(MakeLinkToNewerBlocks(jData), "&nbsp;&#10095;"),"newerBlocks","title='Newer blocks'");
+		text += "</h2>\n"
 		text += "<div class='divTableBlocks'>";
+
 		text += Obj2Html(jData);
 		text += "</div>";
-		text += MakeMoreLink(jData);
+		text +="<p>" + AddClassEx(MakeRef(MakeLinkToOlderBlocks(jData), "Previous blocks..."),"more","title='Previous blocks'") + "</p>";
 
 		SetContent(text);
 	}
@@ -1200,12 +1433,8 @@
 	{
 		const jData = JSON.parse(this.responseText);
 	
-		let text = "<h3>" + MakeRef(UrlSelf("hdrs", ""), "Recent Block Headers") + "</h3>";
-		text += MakeCAs(jData["h"]);
-		text += "<h3>" + MakeRef(UrlSelf("contracts", ""), "Deployed Contracts") + "</h3>";
-
-		text += MakeCollapsibleBegin("Blockchain status");
-		text += "<div class='divTableStatus'>"; // Added to avoid adding filters to these specific tables...
+		let text = "<h2>Blockchain status</h2>";
+		text += "<div class='divTableStatus'>"; // Class added to avoid adding filters to these specific tables...
 		text += Obj2Html(jData);
 		text += "</div>"
 		text += MakeCollapsibleEnd();
@@ -1216,13 +1445,22 @@
 	function DisplayAssets()
 	{
 		const jData = JSON.parse(this.responseText);
-	
-		let text = "<h2>Assets state for height " + MakeBlock(g_CurrentID) + "</h2>\n";
+
+		let text = "<h2>\n"
+		if (g_CurrentID) {
+			text += "Confidential Assets at block height ";
+			text += AddClassEx(MakeRef(UrlSelfWithID("assets", g_CurrentID - 1, ""), "&#10094;&nbsp;"),"olderBlocks","title='Previous Block'");
+			text += MakeBlock(g_CurrentID);
+			text += AddClassEx(MakeRef(UrlSelfWithID("assets", g_CurrentID - 1 + 2, ""), "&nbsp;&#10095;"),"newerBlocks","title='Next Block'");
+		} else {
+			text += "Current Confidential Assets";
+		}
+		text += "</h2>\n"
+
 		text += MakeTblAssets(jData);
 
 		SetContent(text);
 	}
-
 
 	const args = (new URL(document.location)).searchParams;
 	const type = args.get("type");
@@ -1236,6 +1474,9 @@
 	if (hMax)
 		urlSuffix += "&hMax=" + hMax;
 	
+	let nMax = args.get("nMax");
+	if (!nMax)
+		nMax = 100;
 
 	const xmlhttp = new XMLHttpRequest();
 
@@ -1254,13 +1495,26 @@
 	else if (type == "contract")
 	{
 		xmlhttp.onload = DisplayContractState;
-		xmlhttp.open("GET", urlPrefix +  "contract" + urlSuffix + "&id=" + g_CurrentID + "&nMaxTxs=200");
+		xmlhttp.open("GET", urlPrefix +  "contract" + urlSuffix + "&id=" + g_CurrentID + "&nMaxTxs=" + nMax);
 		xmlhttp.send();
 	}
 	else if (type == "hdrs")
 	{
+		// Data that can be requested (relative or absolute):
+		// d = Difficulty
+        // f = Fee
+        // k = Kernels
+        // o = MW Outputs
+        // i = MW Inputs
+        // u = MW UTXOs
+        // O = Shielded Outputs
+        // I = Shielded Inputs
+        // c = Contracts Active
+        // C = Contract Calls
+        // s = Size Compressed
+        // S = Size Archive
 		xmlhttp.onload = DisplayHdrs;
-		xmlhttp.open("GET", urlPrefix +  "hdrs" + urlSuffix + "&nMax=100&cabs=&crel=dfkoOiIC");
+		xmlhttp.open("GET", urlPrefix +  "hdrs" + urlSuffix + "&cabs=&crel=dfkoOiIC" + "&nMax=" + nMax);
 		xmlhttp.send();
 	}
 	else if (type == "contracts")
@@ -1281,20 +1535,141 @@
 		xmlhttp.open("GET", urlPrefix +  "status" + urlSuffix);
 		xmlhttp.send();
 	}
+</script>
+
+<!-- ------------ SECTION 4 - EXTRA JS FUNCTIONS ------------ --> 
+<script>
+
+	// ADD EXPAND OPTIONS TO ALL TEXT OF TYPE HASH OR METADATA (CSS WILL DISPLAYED THEM TRUNCATED BY DEFAULT)
+	function addExpandOptions() {
+		// Text of type Hash (truncated/expanded)
+		for (let myHash of document.querySelectorAll(".cid, .kernelId, .blob, .commitment")) {
+			// Check if the text contains a link
+			let myClass = (myHash.querySelector("a")) ? "truncated withLink" : "truncated";
+			// Add a span to truncate the text, and another span to hold the clickable symbol
+			let myHTML = myHash.innerHTML;
+			myHash.innerHTML = "<span class='" + myClass + "'>" + myHTML + "</span><span class='expand' title='Expand' hidden>&#128065;</span>";
+			// Add event listener on the symbol
+			myHash.querySelector(".expand").addEventListener("click", expandHash);
+		}
+		// Text of type Metadata (reduced/full)
+		for (let myMetadata of document.querySelectorAll(".metadata")) {
+			// Add a span to truncate the text, and another span to hold the clickable symbol
+			let myHTML = myMetadata.innerHTML;
+			myMetadata.innerHTML = "<span class='reduced'>" + myHTML + "</span><span class='extend' title='Expand' hidden>&#128065;</span>";
+			// Add event listener on the symbol
+			myMetadata.querySelector(".extend").addEventListener("click", expandMetadata);
+		}
+	}
+
+	function expandHash(e) {
+		// Get element, table and column number of the event
+		let input = e.currentTarget;
+		// If item is in table, expand the whole column
+		if (input.closest('table')) {
+			let col = input.closest('th,td').cellIndex;
+			let table = input.closest('table');
+			// Loop on all cells in that column
+			for (let myRow of table.rows) {
+				// Remove all truncated classes in the cell
+				for (let myItem of myRow.cells[col].querySelectorAll(".truncated")) {
+					myItem.classList.remove("truncated");
+					myItem.classList.add("expanded");
+				}
+			}
+		} else {
+			// Expand only the item and its siblings
+			for (let myItem of input.parentNode.querySelectorAll(".truncated")) {
+				myItem.classList.remove("truncated");
+				myItem.classList.add("expanded");
+			}
+		}
+	}
+
+	function expandMetadata(e) {
+		// Expand selected metadata only
+		let input = e.currentTarget;
+		for (let myItem of input.parentNode.querySelectorAll(".reduced")) {
+			myItem.classList.remove("reduced");
+			myItem.classList.add("full");
+		}
+	}
+
+	function expandEverything() {
+		// Expand all truncated Hashes
+		for (let myItem of document.querySelectorAll(".truncated")) {
+			myItem.classList.remove("truncated");
+			myItem.classList.add("expanded");
+		}
+		// Expand all truncated Metadata
+		for (let myItem of document.querySelectorAll(".reduced")) {
+			myItem.classList.remove("reduced");
+			myItem.classList.add("full");
+		}
+		// Expand all small collapsible blocks
+		for (let myItem of document.querySelectorAll(".collapsible-checkbox")) {
+			if (myItem.nextElementSibling.classList.contains("small")) {
+				myItem.checked = true;
+			}
+		}
+		// Switch action of the clickable symbol
+		let icon = document.querySelector("#ExpandAll");
+		icon.setAttribute("href", "javascript:truncateEverything();");
+		icon.setAttribute("title", "Truncate everything");
+	}
+
+	function truncateEverything() {
+		// Truncate all Hashes
+		for (let myItem of document.querySelectorAll(".expanded")) {
+			myItem.classList.remove("expanded");
+			myItem.classList.add("truncated");
+		}
+		// Truncate all Metadata
+		for (let myItem of document.querySelectorAll(".full")) {
+			myItem.classList.remove("full");
+			myItem.classList.add("reduced");
+		}
+		// Collapse all small collapsible blocks
+		for (let myItem of document.querySelectorAll(".collapsible-checkbox")) {
+			if (myItem.nextElementSibling.classList.contains("small")) {
+				myItem.checked = false;
+			}
+		}
+		// Switch action of the clickable symbol
+		let icon = document.querySelector("#ExpandAll");
+		icon.setAttribute("href", "javascript:expandEverything();");
+		icon.setAttribute("title", "Expand everything");
+	}
 
 	// ALLOW ADDING FILTERS TO FIRST ROW OF ALL LONG TABLES
 	function addFilterOption() {
 		for (let myTable of document.getElementsByTagName("table")) {
-			// Ignore tables of certain known classes
+			// Ignore tables of certain specific classes
 			if (!myTable.classList.contains("tableTotals") && !myTable.classList.contains("tableSummary") && !myTable.closest('.divTableStatus')) {
 				let myRow = myTable.rows[0];
-				// Apply only to tables with more than a 5 lines
-				if (myTable.rows.length > 5) {
-					myRow.classList.add("filtersOff");
-					myRow.addEventListener("click", addSortAndSearch);			
-				} else {
-					// If *all* cells of the first row have a span with a "th" class, still mark the row as a "header" (but without filters)
-					if (myRow.querySelectorAll("td > span.th").length == myRow.cells.length) {
+				// If all cells of the first row are <th> or have a span with a "th" class, then mark the row as header.
+				// We also enforce the use of <thead> to ensure that the row won't be included in the tbodies that will be filtered and sorted.
+				// And since Chrome 83 (as in Beam Wallet) can only do 'sticky' on 'th' elements, we also change all its 'td' into 'th'.
+				if ((myRow.querySelectorAll("td > span.th").length + myRow.querySelectorAll("th").length) == myRow.cells.length) {
+					// If that first row is not already inside a thead (which means it's implicitely inside a tbody), then create a thead and move the row inside it.
+					if (myRow.parentNode.nodeName != "THEAD") {
+						let myTHead = myTable.createTHead();
+						myTHead.appendChild(myRow);
+					}
+					// Mark the row as header
+					myRow.classList.add("headerRow");
+					// Define all cells in this first row as 'th' (remark: any attribute of those cells are lost, but we don't care)
+					for (let myTd of myRow.cells) {
+						let myTh = document.createElement("th");
+						myTh.innerHTML = myTd.innerHTML;
+						myTd.replaceWith(myTh);
+					}
+					// Add filters only to tables with more than a 5 lines
+					if (myTable.rows.length > 5) {
+						myRow.classList.add("filtersOff");
+						myRow.addEventListener("click", addSortAndSearch);
+						myRow.title = "Click to activate filters"; // This is for the tooltip
+					} else {
 						myRow.classList.add("filtersNot");
 					}
 				}
@@ -1308,10 +1683,11 @@
 		// Get element of the event (the first row)
 		let myRow = e.currentTarget;
 
-		// Replace previous class and remove event
+		// Replace previous class and remove event and title (tooltip)
 		myRow.classList.remove("filtersOff");
 		myRow.classList.add("filtersOn");
 		myRow.removeEventListener("click", addSortAndSearch);
+		myRow.removeAttribute("title");
 
 		// Apply to each cell of the first row (whether 'th' or 'td', it doesn't matter)
 		for (let myHeader of myRow.cells) {
@@ -1319,49 +1695,65 @@
 			// and then add a search input field below it.
 			let myHTML = myHeader.innerHTML;
 			myHeader.innerHTML = "\
-					<div class='headerCell'>\n\
-						<div class='sortable'>" + myHTML + "</div>\n\
-						<input type='text' class='searchable' placeholder='&#x1F50E;&#xFE0E;&nbsp;' autocomplete='off'>\n\
-					</div>\n";
-			// Add event listeners to both elements
+				<div class='headerCell'>\n\
+					<div class='sortable' title='Sort column'>" + myHTML + "</div>\n\
+					<div class='searchable'><input type='text' class='search' title='Enter search term' size='5' placeholder='&#x1F50E;&#xFE0E;&nbsp;' autocomplete='off'></div>\n\
+				</div>\n";
+			// Add event listeners to all elements
 			myHeader.querySelector(".sortable").addEventListener("click", sortTable);
-			myHeader.querySelector(".searchable").addEventListener("keyup", filterTable);
+			myHeader.querySelector(".search").addEventListener("keyup", filterTable);
 		}
 	}
 
 	// SORT ROWS BY CLICKING ON HEADERS (first ascending, then descending)
 	function sortTable(e) {
 		// Declare variables
-		let input, col, tr, table, dir, rows, switching, i, x, y, xVal, yVal, shouldSwitch, switchcount = 0;
+		let input, col, headRow, table, nbr_tbodies, dir, items, switching, i, x, y, xVal, yVal, shouldSwitch, switchcount = 0;
 
 		// Get element, table and column number of the event
 		input = e.currentTarget;
 		col = input.closest('th,td').cellIndex;
-		tr = input.closest('tr');
+		headRow = input.closest('tr');
 		table = input.closest('table');
+		nbr_tbodies = table.tBodies.length;
 
 		// Set the default sorting direction as descending
 		// (or switch to ascending if already sorted descending)
 		dir = (input.classList.contains("desc")) ? "asc" : "desc";
 
-		// Reset all sorting classes in this table headers
-		for (let myHeader of tr.getElementsByClassName("sortable")) {
-			myHeader.className = "sortable";
+		// Reset sorting classes and titles in all headers of this table
+		for (let myHeader of headRow.getElementsByClassName("sortable")) {
+			myHeader.classList.remove("asc");
+			myHeader.classList.remove("desc");
+			myHeader.title = "Sort column";
 		}
 
-		// Make an array with the table rows
-		rows = table.rows;
-		let rowsArray = Array.from(rows);
-		// Remove the first row (the headers)
-		rowsArray.shift();
+		// Get the list of rows or tbodies to be sorted
+		// (Remark: There is always at least one tbody, even if not explictely defined)
+		items = (nbr_tbodies > 1) ? table.tBodies : table.tBodies[0].rows;
+		// Make an array with the items to be sorted
+		let itemsArray = Array.from(items);
 
-		// Make an array from the content of the each cell of the selected column
-		let colArray = rowsArray.map(function(item, index) {
+		// Make an array from the content of the cells in the selected column
+		let colArray = itemsArray.map(function(item, index) {
 			// Get the content of the cell in the column being sorted
-			let myCell = item.getElementsByTagName("td")[col];
-			// Get its value and remove comas (for numbers to be recognized as such).
-			// Also add its initial row index (will allow reordering the table rows).
-			let valArray = [myCell.innerText.replace(/,/g,''), index];
+			// (for tbodies with multiple lines, we concatenate the content of their cells in that column)
+			let val = "";
+			let myCell;
+			if (nbr_tbodies > 1) {
+				// Loop on all rows of the tbody
+				for (let trow of item.rows) {
+					// Concatenate content of each cell
+					if (val != "") {val += "\n"};
+					val += trow.cells[col].innerText;
+				}
+			} else {
+				// Get content of the cell
+				val = item.cells[col].innerText;
+			}
+			// Remove comas (just for numbers to be recognized as such).
+			// And add its initial index (it will allow reordering the actual table rows or tbodies).
+			let valArray = [val.replace(/,/g,''), index];
 			return valArray;
 		});
 
@@ -1382,79 +1774,141 @@
 		});
 		// Reverse the array for descending order
 		if (dir == "desc") {colArray.reverse();}
-		
-		// Remark: The parent of a row is a tbody (even if not explictely defined)
-		let tbody = rows[1].parentNode;
-		// Loop through the array of sorted cells to reorder the table rows
+
+		// Get the 'parent' of the sorted items (i.e. the tbody in the case of rows, or the table in the case of tbodies)
+		// Remark: The parent of a row is always a tbody, even if not explictely defined.
+		let parent = items[0].parentNode;
+		// Loop through the array of sorted cells to reorder the table rows or tbodies
 		for (let sortedCol of colArray) {
-			// Move each corresponding row to the end of the table.
-			tbody.appendChild(rowsArray[sortedCol[1]]);
+			// Move each corresponding row or tbody to the end of the table.
+			parent.appendChild(itemsArray[sortedCol[1]]);
 		}
 
-		// Update class by adding the sorting direction
-		input.className = "sortable " + dir;
+		// Update class and title in header by adding the sorting direction
+		input.classList.add(dir);
+		input.title = (dir == "desc") ? "Sort ascending" : "Sort descending";
 	}
 
-	// FILTER ROWS ACCORDING TO A SEARCH STRING
+	// FILTER ROWS (OR GROUPS OF ROWS)
 	function filterTable(e) {
 		// Declare variables
-		let table, rows, input, filter, i, j, td, txtValue, status;
+		let table, tbodies, rows, trows, headers, input, filter, i, ii, j, k, td, txtValue, status;
 		
-		// Get table and rows
+		// Get tbodies and rows
 		table = e.currentTarget.closest('table');
+		tbodies = table.tBodies;
 		rows = table.rows;
-		
-		// Initialize results array with all 1 (= all rows are visible)
-		let results = new Array(rows.length).fill(1);
+		headers = rows[0].cells;
 
-		// Loop on all header cells (so that multiple searches can be combined!)
-		for (j = 0; j < (rows[0].cells.length); j++) {
+		// If multiple tbodies are present, filtering will be done by tbodies instead of rows
+		// (the inner rows in each tbody thus always being kept together)
+
+		// Initialize results arrays with all 1 (i.e. all rows or tbodies are visible)
+		let results_tbodies = new Array(tbodies.length).fill(1);
+		let results_rows = new Array(rows.length).fill(1);
+
+		// Always check again all header cells (so that filters on multiple columns can be combined!)
+		for (j = 0; j < (headers.length); j++) {
 			// Get search input field
-			input = rows[0].cells[j].querySelector(".searchable");
+			input = headers[j].querySelector(".search");
 			// Get search query (we use toUpperCase() to perform a case-insensitive search)
 			filter = input.value.toUpperCase();
-			// Apply search query if it's non-empty
+			// Apply search query only if it's non-empty
 			if (filter != "") {
-				// Loop on all rows (except header)
-				for (i = 1; i < (rows.length); i++) {
-					// Only test cell if the row is not already marked as hidden
-					if (results[i] != 0) {
-						// Get cell
-						td = rows[i].cells[j];
-						if (td) {
-							// Get cell content
-							txtValue = td.textContent || td.innerText;
-							// Mark row as hidden if there is no match
-							if (txtValue.toUpperCase().indexOf(filter) == -1) {
-								results[i] = 0;
+				// Loop on all rows within all tbodies
+				for (k = 0; k < (tbodies.length); k++) {
+					// Only test cells if the tbody is not already marked as hidden
+					if (results_tbodies[k] != 0) {
+						// In case of multiple tbodies, start by hidding the tbody
+						// (it will be displayed back if at least one of its rows matches the search query)
+						if (tbodies.length > 1) { results_tbodies[k] = 0 }
+						// Loop on all rows of the tbody
+						trows = tbodies[k].rows;
+						for (i = 0; i < (trows.length); i++) {
+							// Get the overall index of the row in the table (independent of tbodies)
+							// Remark: i and ii will be equal in the case of one single tbody
+							ii = trows[i].rowIndex;
+							// Only test the cell if the row is not already marked as hidden
+							if (results_rows[ii] != 0) {
+								// Get cell
+								td = trows[i].cells[j];
+								if (td) {
+									// Get cell content
+									txtValue = td.textContent || td.innerText;
+									// If there are multiple tbodies, then filter by tbodies
+									if (tbodies.length > 1) {
+										// Mark tbody back as visible as soon as one of its rows matches
+										// (and then stop looping on its rows)
+										if (txtValue.toUpperCase().indexOf(filter) != -1) {
+											results_tbodies[k] = 1;
+											break;
+										}
+									// If there is only one tbody, then filter by rows
+									} else {
+										// Hide row if there is no match
+										if (txtValue.toUpperCase().indexOf(filter) == -1) {
+											results_rows[ii] = 0;
+										}
+									}
+								}
 							}
 						}
 					}
 				}
 			}
 		}
-		// Apply final results by hidding all needed rows
-		for (i = 1; i < (rows.length); i++) {
-			status = (results[i] == 0) ? "collapse" : "visible";
-			rows[i].style.visibility = status;
+		// Special hack to avoid a display bug on Chrome 83 (when used as Beam Wallet DApp):
+		// If a tbody is hidden, then each of its rows must also be hidden!
+		if (tbodies.length > 1) {
+			// Loop on all tbodies
+			for (k = 0; k < (tbodies.length); k++) {
+				// Loop on all rows of the tbody
+				trows = tbodies[k].rows;
+				for (i = 0; i < (trows.length); i++) {
+					// Get the overall index of the row in the table (independent of tbodies)
+					ii = trows[i].rowIndex;
+					// Set status of the row identical to the tbody it belongs to
+					results_rows[ii] = results_tbodies[k];
+				}
+			}
+		}
+		// Apply final results by setting the visibility of all tbodies and rows
+		for (k = 0; k < (tbodies.length); k++) {
+			status = (results_tbodies[k] == 0) ? "collapse" : "visible";
+			tbodies[k].style.visibility = status;
+		}
+		for (ii = 1; ii < (rows.length); ii++) {
+			status = (results_rows[ii] == 0) ? "collapse" : "visible";
+			rows[ii].style.visibility = status;
 		}
 	}
 
-	// SCROLL BACK TO TOP
+	// SCROLL DOWN TO BOTTOM OR BACK TO TOP
 	window.onscroll = function() {scrollFunction()};
-	// When the user scrolls down 40px from the top, show the button
+	// When the user scrolls away 40px from top or bottom of the page, show the up or down buttons
 	function scrollFunction() {
-		let mybutton = document.getElementById("TopButton");
+		let myTopButton = document.getElementById("TopButton");
 		if (document.body.scrollTop > 40 || document.documentElement.scrollTop > 40) {
-			mybutton.style.display = "block";
+			myTopButton.style.display = "block";
 		} else {
-			mybutton.style.display = "none";
+			myTopButton.style.display = "none";
+		}
+		let myBottomButton = document.getElementById("BottomButton");
+		if (Math.abs(document.body.scrollHeight - document.body.scrollTop - document.body.clientHeight) > 40 || Math.abs(document.documentElement.scrollHeight - document.documentElement.scrollTop - document.documentElement.clientHeight) > 40) {
+			myBottomButton.style.display = "block";
+		} else {
+			myBottomButton.style.display = "none";
 		}
 	}
-	// When the user clicks on the button, scroll to the top of the document
+	// Scroll to the top of the document
 	function topFunction() {
 		document.body.scrollTop = 0; // For Safari
 		document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+	} 
+	// Scroll to the bottom of the document
+	function bottomFunction() {
+		document.body.scrollTop = Math.abs(document.body.scrollHeight - document.body.clientHeight); // For Safari
+		document.documentElement.scrollTop = Math.abs(document.documentElement.scrollHeight - document.documentElement.clientHeight); // For Chrome, Firefox, IE and Opera
 	} 
 
 </script>

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -114,14 +114,14 @@
 	}
 	.amount {
 		font-family: monospace;
-		font-size: 1.5rem;
-		color: green;
+		font-size: 1.7rem;
+		color: darkcyan;
 	}
 	.amount.pos {
 		color: green; /* Positive values in green */
 	}
 	.amount.neg {
-		color: blue; /* Negative values in blue */
+		color: red; /* Negative values in red */
 	}
 	.th {
 		/* Not sure yet how to use this class (these "headers" can appear in rows or in columns)... */
@@ -447,13 +447,14 @@
 	
 	function MakeAmountClr(amount)
 	{
-		if (!amount)
-			return "";
+		let type = "amount";
 
-		let type = "amount pos";
 		if (amount[0] == '-')
 			type = "amount neg";
-		return AddClass(amount,type);
+		if (amount[0] == '+')
+			type = "amount pos";
+
+		return AddClass(amount, type);
 	}
 
 	function AddClass(txt,className)

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -32,6 +32,7 @@ Disclaimer:
   <link rel="icon" href="data:image/svg+xml,%3Csvg%20viewBox='112%2085%20320%20320'%20xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3EBeam%20favicon%3C/title%3E%3Cpath%20d='m424%20371h-304l152-260zm-229-44%2078-135%2078%20135z'%20fill='%230b76ff'%20fill-rule='evenodd'/%3E%3Cpolygon%20points='225%20314%20272%20226%20320%20314'%20fill='%2339fff2'/%3E%3Cpolygon%20points='120%20192%20272%20278%20272%20287%20120%20246'%20fill='%2324c1ff'/%3E%3Cpolygon%20points='424%20167%20272%20278%20272%20287%20424%20274'%20fill='%23fd76fd'/%3E%3C/svg%3E%0A">
   <title>Beam Smart Explorer</title>
 
+  
 <!-- ------------ SECTION 1 - CSS STYLES ------------ --> 
 <style>
 

--- a/explorer/server.cpp
+++ b/explorer/server.cpp
@@ -804,6 +804,7 @@ OnRequest(hdrs)
 {
     Height hTop = _currentUrl.get_int_arg("hMax", std::numeric_limits<int64_t>::max());
     uint32_t n = (uint32_t) _currentUrl.get_int_arg("nMax", static_cast<uint32_t>(-1));
+    Height dh = _currentUrl.get_int_arg("dh", static_cast<uint32_t>(1));
 
     // defaults
     typedef IAdapter::TotalsFlags F;
@@ -813,7 +814,7 @@ OnRequest(hdrs)
     ReadColFlags(_currentUrl, fAbs, "cabs");
     ReadColFlags(_currentUrl, fRel, "crel");
 
-    return _backend.get_hdrs(hTop, n, fAbs, fRel);
+    return _backend.get_hdrs(hTop, n, dh, fAbs, fRel);
 }
 
 OnRequest(peers)

--- a/hw_crypto/unittest/hw_crypto_test.cpp
+++ b/hw_crypto/unittest/hw_crypto_test.cpp
@@ -1494,7 +1494,7 @@ void TestShielded()
 		ECC::Oracle oracle;
 		oracle << krn.m_Msg;
 
-		if (krn.m_Height.m_Min >= Rules::get().pForks[3].m_Height)
+		if (Rules::get().IsPastFork(krn.m_Height.m_Min, 3))
 		{
 			oracle << krn.m_NotSerialized.m_hvShieldedState;
 			Asset::Proof::Expose(oracle, krn.m_Height.m_Min, krn.m_pAsset);

--- a/hw_crypto/unittest/hw_crypto_test.cpp
+++ b/hw_crypto/unittest/hw_crypto_test.cpp
@@ -1494,7 +1494,7 @@ void TestShielded()
 		ECC::Oracle oracle;
 		oracle << krn.m_Msg;
 
-		if (Rules::get().IsPastFork(krn.m_Height.m_Min, 3))
+		if (Rules::get().IsPastFork_<3>(krn.m_Height.m_Min))
 		{
 			oracle << krn.m_NotSerialized.m_hvShieldedState;
 			Asset::Proof::Expose(oracle, krn.m_Height.m_Min, krn.m_pAsset);

--- a/keykeeper/local_private_key_keeper.cpp
+++ b/keykeeper/local_private_key_keeper.cpp
@@ -135,7 +135,7 @@ namespace beam::wallet
                 !krn.m_vNested.empty())
                 return false; // non-trivial kernels should not be supported
 
-            if ((krn.m_Height.m_Min < Rules::get().pForks[1].m_Height) && m_This.IsTrustless())
+            if (!(Rules::get().IsPastFork(krn.m_Height.m_Min, 1)) && m_This.IsTrustless())
                 return false; // disallow weak scheme
         }
 
@@ -293,7 +293,7 @@ namespace beam::wallet
         if (IsTrustless())
         {
             // disallow weak paramters
-            if (x.m_hScheme < Rules::get().pForks[1].m_Height)
+            if (!Rules::get().IsPastFork(x.m_hScheme, 1))
                 return Status::Unspecified; // blinding factor can be tampered without user permission
         }
 

--- a/keykeeper/local_private_key_keeper.cpp
+++ b/keykeeper/local_private_key_keeper.cpp
@@ -135,7 +135,7 @@ namespace beam::wallet
                 !krn.m_vNested.empty())
                 return false; // non-trivial kernels should not be supported
 
-            if (!(Rules::get().IsPastFork(krn.m_Height.m_Min, 1)) && m_This.IsTrustless())
+            if (!(Rules::get().IsPastFork_<1>(krn.m_Height.m_Min)) && m_This.IsTrustless())
                 return false; // disallow weak scheme
         }
 
@@ -293,7 +293,7 @@ namespace beam::wallet
         if (IsTrustless())
         {
             // disallow weak paramters
-            if (!Rules::get().IsPastFork(x.m_hScheme, 1))
+            if (!Rules::get().IsPastFork_<1>(x.m_hScheme))
                 return Status::Unspecified; // blinding factor can be tampered without user permission
         }
 

--- a/keykeeper/remote_key_keeper.cpp
+++ b/keykeeper/remote_key_keeper.cpp
@@ -730,7 +730,7 @@ namespace beam::wallet
         {
             if (!m_Phase)
             {
-                if (m_M.m_hScheme < Rules::get().pForks[1].m_Height)
+                if (!Rules::get().IsPastFork(m_M.m_hScheme, 1))
                 {
                     Fin(Status::NotImplemented);
                     return;
@@ -1058,7 +1058,7 @@ namespace beam::wallet
             krn.UpdateMsg();
             m_Oracle << krn.m_Msg;
 
-            if (krn.m_Height.m_Min >= Rules::get().pForks[3].m_Height)
+            if (Rules::get().IsPastFork(krn.m_Height.m_Min, 3))
             {
                 m_Oracle << krn.m_NotSerialized.m_hvShieldedState;
                 Asset::Proof::Expose(m_Oracle, krn.m_Height.m_Min, krn.m_pAsset);

--- a/keykeeper/remote_key_keeper.cpp
+++ b/keykeeper/remote_key_keeper.cpp
@@ -730,7 +730,7 @@ namespace beam::wallet
         {
             if (!m_Phase)
             {
-                if (!Rules::get().IsPastFork(m_M.m_hScheme, 1))
+                if (!Rules::get().IsPastFork_<1>(m_M.m_hScheme))
                 {
                     Fin(Status::NotImplemented);
                     return;
@@ -1058,7 +1058,7 @@ namespace beam::wallet
             krn.UpdateMsg();
             m_Oracle << krn.m_Msg;
 
-            if (Rules::get().IsPastFork(krn.m_Height.m_Min, 3))
+            if (Rules::get().IsPastFork_<3>(krn.m_Height.m_Min))
             {
                 m_Oracle << krn.m_NotSerialized.m_hvShieldedState;
                 Asset::Proof::Expose(m_Oracle, krn.m_Height.m_Min, krn.m_pAsset);

--- a/keykeeper/trezor_key_keeper.cpp
+++ b/keykeeper/trezor_key_keeper.cpp
@@ -739,7 +739,7 @@ namespace beam::wallet
 
     void TrezorKeyKeeperProxy::InvokeAsync(Method::CreateOutput& m, const Handler::Ptr& h)
     {
-        if (m.m_hScheme < Rules::get().pForks[1].m_Height)
+        if (!Rules::get().IsPastFork(m.m_hScheme, 1))
             return PushOut(Status::NotImplemented, h);
         
         CreateOutputCtx::Ptr pCtx = std::make_unique<CreateOutputCtx>(*this, m);

--- a/keykeeper/trezor_key_keeper.cpp
+++ b/keykeeper/trezor_key_keeper.cpp
@@ -739,7 +739,7 @@ namespace beam::wallet
 
     void TrezorKeyKeeperProxy::InvokeAsync(Method::CreateOutput& m, const Handler::Ptr& h)
     {
-        if (!Rules::get().IsPastFork(m.m_hScheme, 1))
+        if (!Rules::get().IsPastFork_<1>(m.m_hScheme))
             return PushOut(Status::NotImplemented, h);
         
         CreateOutputCtx::Ptr pCtx = std::make_unique<CreateOutputCtx>(*this, m);

--- a/node/node.cpp
+++ b/node/node.cpp
@@ -2555,7 +2555,7 @@ bool Node::CalculateFeeReserve(const TxStats& s, const HeightRange& hr, const Am
 {
     feeReserve = static_cast<Amount>(-1);
 
-    if (hr.m_Min >= Rules::get().pForks[1].m_Height)
+    if (Rules::get().IsPastFork(hr.m_Min, 1))
     {
         auto& fs = Transaction::FeeSettings::get(hr.m_Min);
         Amount feesMin = fs.Calculate(s);
@@ -3858,7 +3858,7 @@ void Node::Peer::OnMsg(proto::GetExternalAddr&& msg)
 
 void Node::Peer::OnMsg(proto::BbsMsg&& msg)
 {
-	if ((m_This.m_Processor.m_Cursor.m_ID.m_Height >= Rules::get().pForks[1].m_Height) && !Rules::get().FakePoW)
+	if (Rules::get().IsPastFork(m_This.m_Processor.m_Cursor.m_ID.m_Height, 1) && !Rules::get().FakePoW)
 	{
 		// test the hash
 		ECC::Hash::Value hv;
@@ -5260,7 +5260,7 @@ bool Node::GenerateRecoveryInfo(const char* szPath)
 
         const Rules& r = Rules::get();
 
-        if (m_Processor.m_Cursor.m_ID.m_Height >= r.pForks[2].m_Height)
+        if (r.IsPastFork(m_Processor.m_Cursor.m_ID.m_Height, 2))
         {
             MySerializer ser(ctx.m_Writer.m_Stream);
             ser & MaxHeight; // terminator
@@ -5298,7 +5298,7 @@ bool Node::GenerateRecoveryInfo(const char* szPath)
                     m_Ser & krn.m_Txo;
                     m_Ser & krn.m_Msg;
 
-                    if (pAsset && (m_Height >= Rules::get().pForks[3].m_Height))
+                    if (pAsset && Rules::get().IsPastFork(m_Height, 3))
                         m_Ser & pAsset->m_hGen;
 
                     return true;
@@ -5316,7 +5316,7 @@ bool Node::GenerateRecoveryInfo(const char* szPath)
 
             while (m_Processor.get_DB().AssetGetNext(ai))
             {
-                if (m_Processor.m_Cursor.m_ID.m_Height < r.pForks[6].m_Height)
+                if (!r.IsPastFork(m_Processor.m_Cursor.m_ID.m_Height, 6))
                     ai.SetCid(nullptr);
 
                 ser & ai;
@@ -5324,7 +5324,7 @@ bool Node::GenerateRecoveryInfo(const char* szPath)
 
             ser & (Asset::s_MaxCount + 1); // terminator
 
-            if (m_Processor.m_Cursor.m_ID.m_Height >= r.pForks[3].m_Height)
+            if (r.IsPastFork(m_Processor.m_Cursor.m_ID.m_Height, 3))
             {
                 m_Processor.EnsureCursorKernels();
 

--- a/node/node.cpp
+++ b/node/node.cpp
@@ -2555,7 +2555,7 @@ bool Node::CalculateFeeReserve(const TxStats& s, const HeightRange& hr, const Am
 {
     feeReserve = static_cast<Amount>(-1);
 
-    if (Rules::get().IsPastFork(hr.m_Min, 1))
+    if (Rules::get().IsPastFork_<1>(hr.m_Min))
     {
         auto& fs = Transaction::FeeSettings::get(hr.m_Min);
         Amount feesMin = fs.Calculate(s);
@@ -3858,7 +3858,7 @@ void Node::Peer::OnMsg(proto::GetExternalAddr&& msg)
 
 void Node::Peer::OnMsg(proto::BbsMsg&& msg)
 {
-	if (Rules::get().IsPastFork(m_This.m_Processor.m_Cursor.m_ID.m_Height, 1) && !Rules::get().FakePoW)
+	if (Rules::get().IsPastFork_<1>(m_This.m_Processor.m_Cursor.m_ID.m_Height) && !Rules::get().FakePoW)
 	{
 		// test the hash
 		ECC::Hash::Value hv;
@@ -5260,7 +5260,7 @@ bool Node::GenerateRecoveryInfo(const char* szPath)
 
         const Rules& r = Rules::get();
 
-        if (r.IsPastFork(m_Processor.m_Cursor.m_ID.m_Height, 2))
+        if (r.IsPastFork_<2>(m_Processor.m_Cursor.m_ID.m_Height))
         {
             MySerializer ser(ctx.m_Writer.m_Stream);
             ser & MaxHeight; // terminator
@@ -5298,7 +5298,7 @@ bool Node::GenerateRecoveryInfo(const char* szPath)
                     m_Ser & krn.m_Txo;
                     m_Ser & krn.m_Msg;
 
-                    if (pAsset && Rules::get().IsPastFork(m_Height, 3))
+                    if (pAsset && Rules::get().IsPastFork_<3>(m_Height))
                         m_Ser & pAsset->m_hGen;
 
                     return true;
@@ -5316,7 +5316,7 @@ bool Node::GenerateRecoveryInfo(const char* szPath)
 
             while (m_Processor.get_DB().AssetGetNext(ai))
             {
-                if (!r.IsPastFork(m_Processor.m_Cursor.m_ID.m_Height, 6))
+                if (!r.IsPastFork_<6>(m_Processor.m_Cursor.m_ID.m_Height))
                     ai.SetCid(nullptr);
 
                 ser & ai;
@@ -5324,7 +5324,7 @@ bool Node::GenerateRecoveryInfo(const char* szPath)
 
             ser & (Asset::s_MaxCount + 1); // terminator
 
-            if (r.IsPastFork(m_Processor.m_Cursor.m_ID.m_Height, 3))
+            if (r.IsPastFork_<3>(m_Processor.m_Cursor.m_ID.m_Height))
             {
                 m_Processor.EnsureCursorKernels();
 

--- a/node/processor.cpp
+++ b/node/processor.cpp
@@ -1103,7 +1103,7 @@ bool NodeProcessor::MultiShieldedContext::IsValid(const TxKernelShieldedInput& k
 	ECC::Oracle oracle;
 	oracle << krn.m_Msg;
 
-	if (Rules::get().IsPastFork(hScheme, 3))
+	if (Rules::get().IsPastFork_<3>(hScheme))
 	{
 		oracle << krn.m_NotSerialized.m_hvShieldedState;
 		Asset::Proof::Expose(oracle, hScheme, krn.m_pAsset);
@@ -1181,7 +1181,7 @@ bool NodeProcessor::MultiShieldedContext::IsValid(const TxVectors::Eternal& txve
 
 void NodeProcessor::MultiShieldedContext::Prepare(const TxVectors::Eternal& txve, NodeProcessor& np, Height h)
 {
-	if (!Rules::get().IsPastFork(h, 3))
+	if (!Rules::get().IsPastFork_<3>(h))
 		return;
 
 	struct MyWalker
@@ -1269,7 +1269,7 @@ bool NodeProcessor::MultiAssetContext::BatchCtx::IsValid(Height hScheme, ECC::Po
 	if (!p.IsValidPrepare(hGen, bc, &m_vKs.front()))
 		return false;
 
-	if (r.IsPastFork(hScheme, 6))
+	if (r.IsPastFork_<6>(hScheme))
 	{
 		m_Ctx.Add(0, 1, &m_vKs.front());
 		m_Ctx.Add(p.m_Begin + 1u, N - 1, &m_vKs.front() + 1);
@@ -2375,7 +2375,7 @@ Height NodeProcessor::get_ProofKernel(Merkle::Proof& proof, TxKernel::Ptr* ppRes
 
 	mmr.get_Proof(proof, iTrg);
 
-	if (Rules::get().IsPastFork(sid.m_Height, 3))
+	if (Rules::get().IsPastFork_<3>(sid.m_Height))
 	{
 		struct MyProofBuilder
 			:public ProofBuilder_PrevState
@@ -2951,7 +2951,7 @@ bool NodeProcessor::HandleBlock(const NodeDB::StateID& sid, const Block::SystemS
 	Merkle::Hash hvDef;
 	ev.m_Height++;
 
-	bool bPastFork3 = Rules::get().IsPastFork(sid.m_Height, 3);
+	bool bPastFork3 = Rules::get().IsPastFork_<3>(sid.m_Height);
 	bool bPastFastSync = (sid.m_Height >= m_SyncData.m_TxoLo);
 	bool bDefinition = bPastFork3 || bPastFastSync;
 
@@ -3668,7 +3668,7 @@ Height NodeProcessor::FindVisibleKernel(const Merkle::Hash& id, const BlockInter
 		assert(h <= bic.m_Height);
 
 		const Rules& r = Rules::get();
-		if (r.IsPastFork(bic.m_Height, 2) && (bic.m_Height - h > r.MaxKernelValidityDH))
+		if (r.IsPastFork_<2>(bic.m_Height) && (bic.m_Height - h > r.MaxKernelValidityDH))
 			return 0; // Starting from Fork2 - visibility horizon is limited
 	}
 
@@ -3907,7 +3907,7 @@ bool NodeProcessor::HandleAssetDestroy2(const PeerID& pidOwner, const ContractID
 			& ai.m_Metadata
 			& ai.m_LockHeight;
 
-		if (Rules::get().IsPastFork(bic.m_Height, 5))
+		if (Rules::get().IsPastFork_<5>(bic.m_Height))
 			ser & ai.m_Deposit;
 		else
 			assert(Rules::get().CA.DepositForList2 == ai.m_Deposit);
@@ -3938,7 +3938,7 @@ bool NodeProcessor::HandleAssetDestroy2(const PeerID& pidOwner, const ContractID
 		else
 			ai.m_Owner = pidOwner;
 
-		if (Rules::get().IsPastFork(bic.m_Height, 5))
+		if (Rules::get().IsPastFork_<5>(bic.m_Height))
 			der & ai.m_Deposit;
 		else
 			ai.m_Deposit = Rules::get().CA.DepositForList2;
@@ -4597,7 +4597,7 @@ void NodeProcessor::ManageKrnID(BlockInterpretCtx& bic, const TxKernel& krn)
 bool NodeProcessor::HandleBlockElement(const TxKernel& v, BlockInterpretCtx& bic)
 {
 	const Rules& r = Rules::get();
-	if (bic.m_Fwd && r.IsPastFork(bic.m_Height, 2) && !bic.m_AlreadyValidated)
+	if (bic.m_Fwd && r.IsPastFork_<2>(bic.m_Height) && !bic.m_AlreadyValidated)
 	{
 		Height hPrev = FindVisibleKernel(v.m_Internal.m_ID, bic);
 		if (hPrev >= Rules::HeightGenesis)
@@ -4917,7 +4917,7 @@ bool NodeProcessor::BlockInterpretCtx::BvmProcessor::Invoke(const bvm2::Contract
 		m_Stack.PushAlias(krn.m_Args);
 
 		m_Instruction.m_Mode = 
-			IsPastHF4() ?
+			IsPastFork_<4>() ?
 			Wasm::Reader::Mode::Standard :
 			m_Bic.m_TxValidation ?
 				Wasm::Reader::Mode::Restrict :
@@ -6135,7 +6135,7 @@ Difficulty NodeProcessor::get_NextDifficulty()
 	// actual dt, only making sure it's non-negative
 	uint32_t dtSrc_s = (thw1.first > thw0.first) ? static_cast<uint32_t>(thw1.first - thw0.first) : 0;
 
-	if (r.IsPastFork(m_Cursor.m_Full.m_Height, 1))
+	if (r.IsPastFork_<1>(m_Cursor.m_Full.m_Height))
 	{
 		// Apply dampening. Recalculate dtSrc_s := dtSrc_s * M/N + dtTrg_s * (N-M)/N
 		// Use 64-bit arithmetic to avoid overflow
@@ -6600,7 +6600,7 @@ void NodeProcessor::GenerateNewHdr(BlockContext& bc, BlockInterpretCtx& bic)
 
 	ev.get_Definition(bc.m_Hdr.m_Definition);
 
-	if (Rules::get().IsPastFork(ev.m_Height, 3))
+	if (Rules::get().IsPastFork_<3>(ev.m_Height))
 		get_Utxos().get_Hash(bc.m_Hdr.m_Kernels);
 	else
 		bc.m_Hdr.m_Kernels = ev.m_hvKernels;

--- a/node/unittests/node_test.cpp
+++ b/node/unittests/node_test.cpp
@@ -1003,7 +1003,7 @@ namespace beam
 			mk.m_bUseHashlock = 0 != (1 & h);
 			mk.m_Height = h;
 
-			if (!(m_hvKrnRel == Zero) && Rules::get().IsPastFork(h, 1))
+			if (!(m_hvKrnRel == Zero) && Rules::get().IsPastFork_<1>(h))
 			{
 				mk.m_hvRelLock = m_hvKrnRel;
 				m_hvKrnRel = Zero;
@@ -1930,7 +1930,7 @@ namespace beam
 			bool SendShielded()
 			{
 				Height h = m_vStates.back().m_Height;
-				if ((h < 2) || !Rules::get().IsPastFork(h - 2, 2))
+				if ((h < 2) || !Rules::get().IsPastFork_<2>(h - 2))
 					return false;
 
 				proto::NewTransaction msgTx;
@@ -2365,7 +2365,7 @@ namespace beam
 					return false;
 
 				const Block::SystemState::Full& s = m_vStates.back();
-				if (!Rules::get().IsPastFork(s.m_Height + 1, 2))
+				if (!Rules::get().IsPastFork_<2>(s.m_Height + 1))
 					return false;
 
 				const Amount nFee = 330;
@@ -2410,7 +2410,7 @@ namespace beam
 					return false;
 
 				const Block::SystemState::Full& s = m_vStates.back();
-				if (!Rules::get().IsPastFork(s.m_Height + 1, 2))
+				if (!Rules::get().IsPastFork_<2>(s.m_Height + 1))
 					return false;
 
 				val -= nFee;
@@ -2596,7 +2596,7 @@ namespace beam
 			bool MaybeInvokeContract(proto::NewTransaction& msg, Amount& val)
 			{
 				const Block::SystemState::Full& s = m_vStates.back();
-				if (!Rules::get().IsPastFork(s.m_Height + 1, 3))
+				if (!Rules::get().IsPastFork_<3>(s.m_Height + 1))
 					return false;
 
 				if (m_pMan)

--- a/node/unittests/node_test.cpp
+++ b/node/unittests/node_test.cpp
@@ -1003,7 +1003,7 @@ namespace beam
 			mk.m_bUseHashlock = 0 != (1 & h);
 			mk.m_Height = h;
 
-			if (!(m_hvKrnRel == Zero) && (h >= Rules::get().pForks[1].m_Height))
+			if (!(m_hvKrnRel == Zero) && Rules::get().IsPastFork(h, 1))
 			{
 				mk.m_hvRelLock = m_hvKrnRel;
 				m_hvKrnRel = Zero;
@@ -1930,7 +1930,7 @@ namespace beam
 			bool SendShielded()
 			{
 				Height h = m_vStates.back().m_Height;
-				if (h + 1 < Rules::get().pForks[2].m_Height + 3)
+				if ((h < 2) || !Rules::get().IsPastFork(h - 2, 2))
 					return false;
 
 				proto::NewTransaction msgTx;
@@ -2365,7 +2365,7 @@ namespace beam
 					return false;
 
 				const Block::SystemState::Full& s = m_vStates.back();
-				if (s.m_Height + 1 < Rules::get().pForks[2].m_Height)
+				if (!Rules::get().IsPastFork(s.m_Height + 1, 2))
 					return false;
 
 				const Amount nFee = 330;
@@ -2410,7 +2410,7 @@ namespace beam
 					return false;
 
 				const Block::SystemState::Full& s = m_vStates.back();
-				if (s.m_Height + 1 < Rules::get().pForks[2].m_Height)
+				if (!Rules::get().IsPastFork(s.m_Height + 1, 2))
 					return false;
 
 				val -= nFee;
@@ -2596,7 +2596,7 @@ namespace beam
 			bool MaybeInvokeContract(proto::NewTransaction& msg, Amount& val)
 			{
 				const Block::SystemState::Full& s = m_vStates.back();
-				if (s.m_Height + 1 < Rules::get().pForks[3].m_Height)
+				if (!Rules::get().IsPastFork(s.m_Height + 1, 3))
 					return false;
 
 				if (m_pMan)

--- a/node/utils/node_net_sim.cpp
+++ b/node/utils/node_net_sim.cpp
@@ -512,7 +512,7 @@ struct Context
         Height h = m_FlyClient.get_Height();
         std::cout << "H=" << h << std::endl;
 
-        if (!Rules::get().IsPastFork(h, 2))
+        if (!Rules::get().IsPastFork_<2>(h))
             return;
 
         std::cout << "\tTotal shielded in/outs: " << (m_pProc->m_Mmr.m_Shielded.m_Count - m_pProc->m_Extra.m_ShieldedOutputs) << " / " << m_pProc->m_Extra.m_ShieldedOutputs << std::endl;

--- a/node/utils/node_net_sim.cpp
+++ b/node/utils/node_net_sim.cpp
@@ -512,7 +512,7 @@ struct Context
         Height h = m_FlyClient.get_Height();
         std::cout << "H=" << h << std::endl;
 
-        if (h < Rules::get().pForks[2].m_Height)
+        if (!Rules::get().IsPastFork(h, 2))
             return;
 
         std::cout << "\tTotal shielded in/outs: " << (m_pProc->m_Mmr.m_Shielded.m_Count - m_pProc->m_Extra.m_ShieldedOutputs) << " / " << m_pProc->m_Extra.m_ShieldedOutputs << std::endl;

--- a/pow/beamHash.cpp
+++ b/pow/beamHash.cpp
@@ -35,10 +35,10 @@ struct Block::PoW::Helper
 	PoWScheme* getCurrentPoW(Height h) {
 
 		const Rules& r = Rules::get();
-		if (r.IsPastFork(h, 2))
+		if (r.IsPastFork_<2>(h))
 			return &BeamHashIII;
 
-		if (r.IsPastFork(h, 1))
+		if (r.IsPastFork_<1>(h))
 			return &BeamHashII;
 		
 		return &BeamHashI;

--- a/pow/beamHash.cpp
+++ b/pow/beamHash.cpp
@@ -33,13 +33,15 @@ struct Block::PoW::Helper
 	BeamHash_III       BeamHashIII;
 
 	PoWScheme* getCurrentPoW(Height h) {
-		if (h < Rules::get().pForks[1].m_Height) {
-			return &BeamHashI;
-		} else if (h < Rules::get().pForks[2].m_Height) {
-			return &BeamHashII;
-		} else {
+
+		const Rules& r = Rules::get();
+		if (r.IsPastFork(h, 2))
 			return &BeamHashIII;
-		}
+
+		if (r.IsPastFork(h, 1))
+			return &BeamHashII;
+		
+		return &BeamHashI;
 	}
 
 	void Reset(const void* pInput, uint32_t nSizeInput, const NonceType& nonce, Height h)

--- a/pow/stratum_server.cpp
+++ b/pow/stratum_server.cpp
@@ -136,9 +136,7 @@ bool Server::on_login(uint64_t from, const Login& login) {
 
     Result res(login.id, loginSuccess ? stratum::no_error : stratum::login_failed);
     res.nonceprefix = conn->get_nonceprefix();
-    res.forkheight = Rules::get().pForks[1].m_Height;
-    res.forkheight2 = Rules::get().pForks[2].m_Height;
-    std::cout << "Fork Heights: " << Rules::get().pForks[1].m_Height << " " <<  Rules::get().pForks[2].m_Height << std::endl;
+
     append_json_msg(_fw, res);
     bool sent = conn->send_msg(_currentMsg, false, !loginSuccess);
     _currentMsg.clear();

--- a/utility/cli/options.cpp
+++ b/utility/cli/options.cpp
@@ -309,6 +309,7 @@ namespace beam
         const char* SHADER_PRIVILEGE         = "shader_privilege";
         const char* SHADER_DEBUG             = "shader_debug";
         const char* SHADER_WIDGET            = "widget";
+        const char* SHADER_WIDGET_NAME       = "name";
 
         // IPFS
         #ifdef BEAM_IPFS_SUPPORT
@@ -476,6 +477,7 @@ namespace beam
             (cli::SHADER_DEBUG, po::value<bool>()->default_value(false), "shader debug")
             (cli::SHADER_BYTECODE_APP, po::value<string>()->default_value(""), "Path to the app shader file")
             (cli::SHADER_BYTECODE_CONTRACT, po::value<string>()->default_value(""), "Path to the shader file for the contract (if the contract is being-created)")
+            (cli::SHADER_WIDGET_NAME, po::value<string>(), "Name of the widget")
             (cli::MAX_PRIVACY_ADDRESS, po::bool_switch()->default_value(false), "generate max privacy transaction address")
             (cli::OFFLINE_COUNT, po::value<Positive<uint32_t>>(), "generate offline transaction address with given number of payments")
             (cli::PUBLIC_OFFLINE, po::bool_switch()->default_value(false), "generate an offline public address for donates (less secure, but more convenient)")

--- a/utility/cli/options.cpp
+++ b/utility/cli/options.cpp
@@ -308,6 +308,7 @@ namespace beam
         const char* SHADER_BYTECODE_CONTRACT = "shader_contract_file";
         const char* SHADER_PRIVILEGE         = "shader_privilege";
         const char* SHADER_DEBUG             = "shader_debug";
+        const char* SHADER_WIDGET            = "widget";
 
         // IPFS
         #ifdef BEAM_IPFS_SUPPORT

--- a/utility/cli/options.h
+++ b/utility/cli/options.h
@@ -272,6 +272,7 @@ namespace beam
         extern const char* SHADER_PRIVILEGE;
         extern const char* SHADER_DEBUG;
         extern const char* SHADER_WIDGET;
+        extern const char* SHADER_WIDGET_NAME;
 
         // IPFS
         #ifdef BEAM_IPFS_SUPPORT

--- a/utility/cli/options.h
+++ b/utility/cli/options.h
@@ -271,6 +271,7 @@ namespace beam
         extern const char* SHADER_BYTECODE_CONTRACT;
         extern const char* SHADER_PRIVILEGE;
         extern const char* SHADER_DEBUG;
+        extern const char* SHADER_WIDGET;
 
         // IPFS
         #ifdef BEAM_IPFS_SUPPORT

--- a/wallet/api/v6_0/v6_api_handle.cpp
+++ b/wallet/api/v6_0/v6_api_handle.cpp
@@ -967,16 +967,8 @@ namespace beam::wallet
         Merkle::Hash blockHash;
         state.get_Hash(blockHash);
 
-        std::string rulesHash = Rules::get().pForks[_countof(Rules::get().pForks) - 1].m_Hash.str();
-
-        for (size_t i = 1; i < _countof(Rules::get().pForks); i++)
-        {
-            if (state.m_Height < Rules::get().pForks[i].m_Height)
-            {
-                rulesHash = Rules::get().pForks[i - 1].m_Hash.str();
-                break;
-            }
-        }
+        const Rules& r = Rules::get();
+        std::string rulesHash = r.pForks[r.FindFork(state.m_Height)].m_Hash.str();
 
         BlockDetails::Response response;
         response.height = state.m_Height;

--- a/wallet/cli/cli.cpp
+++ b/wallet/cli/cli.cpp
@@ -2919,16 +2919,8 @@ namespace
         Merkle::Hash blockHash;
         state.get_Hash(blockHash);
 
-        std::string rulesHash = Rules::get().pForks[_countof(Rules::get().pForks) - 1].m_Hash.str();
-
-        for (size_t i = 1; i < _countof(Rules::get().pForks); i++)
-        {
-            if (state.m_Height < Rules::get().pForks[i].m_Height)
-            {
-                rulesHash = Rules::get().pForks[i - 1].m_Hash.str();
-                break;
-            }
-        }
+        const Rules& r = Rules::get();
+        std::string rulesHash = r.pForks[r.FindFork(state.m_Height)].m_Hash.str();
 
         std::cout << "Block Details:" << "\n"
             << "Height: " << state.m_Height << "\n"

--- a/wallet/cli/cli.cpp
+++ b/wallet/cli/cli.cpp
@@ -2348,9 +2348,6 @@ namespace
             };
         }
 
-#ifdef BEAM_ASSET_SWAP_SUPPORT
-        AssetsSwapCliHandler assetsSwapHandler;
-#endif  // BEAM_ASSET_SWAP_SUPPORT
         auto wallet = std::make_shared<Wallet>(walletDB,
             std::move(txCompletedAction),
             Wallet::UpdateCompletedAction());
@@ -2391,6 +2388,7 @@ namespace
             wallet->ResumeAllTransactions();
 
 #ifdef BEAM_ASSET_SWAP_SUPPORT
+            AssetsSwapCliHandler assetsSwapHandler;
             assetsSwapHandler.init(wallet, walletDB, nnet, *wnet);
 #endif  // BEAM_ASSET_SWAP_SUPPORT
 

--- a/wallet/cli/cli.cpp
+++ b/wallet/cli/cli.cpp
@@ -2378,8 +2378,6 @@ namespace
             {
                 wallet->EnableBodyRequests(true);
             }
-            wallet->ResumeAllTransactions();
-
             auto nnet = CreateNetwork(*wallet, vm);
             if (!nnet)
             {
@@ -2389,6 +2387,8 @@ namespace
             auto wnet = make_shared<WalletNetworkViaBbs>(*wallet, nnet, walletDB);
             wallet->AddMessageEndpoint(wnet);
             wallet->SetNodeEndpoint(nnet);
+
+            wallet->ResumeAllTransactions();
 
 #ifdef BEAM_ASSET_SWAP_SUPPORT
             assetsSwapHandler.init(wallet, walletDB, nnet, *wnet);

--- a/wallet/cli/cli.cpp
+++ b/wallet/cli/cli.cpp
@@ -2626,11 +2626,17 @@ namespace
     {
         return DoWalletFunc(vm, [](const po::variables_map& vm, auto&& wallet, auto&& walletDB, auto& currentTxID)
             {
+                auto sName = vm[cli::SHADER_WIDGET_NAME].as<std::string>();
+                if (sName.empty())
+                {
+                    std::cout << "widget name should not be empty";
+                    return 1;
+                }
                 auto sPath = vm[cli::SHADER_BYTECODE_APP].as<std::string>();
 
                 ByteBuffer buf;
                 if (sPath.empty())
-                    std::cout << "Widget shader reset" << std::endl;
+                    std::cout << "Widget " << sName << " removed" << std::endl;
                 else
                 {
                     CompileShader(buf, sPath.c_str(), bvm2::Processor::Kind::Manager);
@@ -2638,10 +2644,10 @@ namespace
                     bvm2::ShaderID sid;
                     bvm2::get_ShaderID(sid, buf);
 
-                    std::cout << "Widget sid: " << sid << std::endl;
+                    std::cout << "Widget " << sName << " sid: " << sid << std::endl;
                 }
 
-                wallet->SetWidget(std::move(buf));
+                wallet->SetWidget(std::move(sName), std::move(buf));
                 return 0;
             });
     }

--- a/wallet/client/extensions/news_channels/exchange_rate_provider.cpp
+++ b/wallet/client/extensions/news_channels/exchange_rate_provider.cpp
@@ -111,7 +111,7 @@ namespace beam::wallet
             Block::SystemState::ID state;
             if (m_storage.getSystemStateID(state))
             {
-                if (Rules::get().IsPastFork(state.m_Height, 3)) // we do not process old versioned messages
+                if (Rules::get().IsPastFork_<3>(state.m_Height)) // we do not process old versioned messages
                 {
                     std::vector<ExchangeRate> receivedRates;
                     if (fromByteBuffer(buffer, receivedRates))

--- a/wallet/client/extensions/news_channels/exchange_rate_provider.cpp
+++ b/wallet/client/extensions/news_channels/exchange_rate_provider.cpp
@@ -111,7 +111,7 @@ namespace beam::wallet
             Block::SystemState::ID state;
             if (m_storage.getSystemStateID(state))
             {
-                if (state.m_Height >= Rules::get().pForks[3].m_Height) // we do not process old versioned messages
+                if (Rules::get().IsPastFork(state.m_Height, 3)) // we do not process old versioned messages
                 {
                     std::vector<ExchangeRate> receivedRates;
                     if (fromByteBuffer(buffer, receivedRates))

--- a/wallet/client/wallet_client.cpp
+++ b/wallet/client/wallet_client.cpp
@@ -1067,11 +1067,6 @@ namespace beam::wallet
         return m_thread && m_thread->joinable();
     }
 
-    bool WalletClient::isFork1() const
-    {
-        return m_currentHeight >= getRules().pForks[1].m_Height;
-    }
-
     size_t WalletClient::getUnsafeActiveTransactionsCount() const
     {
         return m_unsafeActiveTxCount;

--- a/wallet/client/wallet_client.h
+++ b/wallet/client/wallet_client.h
@@ -142,7 +142,6 @@ namespace beam::wallet
         std::string getNodeAddress() const;
         std::string exportOwnerKey(const beam::SecString& pass) const;
         bool isRunning() const;
-        bool isFork1() const;
         size_t getUnsafeActiveTransactionsCount() const;
         size_t getUnreadNotificationsCount() const;
         bool isConnectionTrusted() const;   

--- a/wallet/core/base_tx_builder.cpp
+++ b/wallet/core/base_tx_builder.cpp
@@ -918,7 +918,7 @@ namespace beam::wallet
     void BaseTxBuilder::CheckMinimumFee(const TxStats* pFromPeer /* = nullptr */)
     {
         // after 1st fork fee should be >= minimal fee
-        if (Rules::get().pForks[1].m_Height <= m_Height.m_Min)
+        if (Rules::get().IsPastFork(m_Height.m_Min, 1))
         {
             Amount feeInps = 0;
             for (const auto& si : m_Coins.m_InputShielded)

--- a/wallet/core/base_tx_builder.cpp
+++ b/wallet/core/base_tx_builder.cpp
@@ -918,7 +918,7 @@ namespace beam::wallet
     void BaseTxBuilder::CheckMinimumFee(const TxStats* pFromPeer /* = nullptr */)
     {
         // after 1st fork fee should be >= minimal fee
-        if (Rules::get().IsPastFork(m_Height.m_Min, 1))
+        if (Rules::get().IsPastFork_<1>(m_Height.m_Min))
         {
             Amount feeInps = 0;
             for (const auto& si : m_Coins.m_InputShielded)

--- a/wallet/core/common.cpp
+++ b/wallet/core/common.cpp
@@ -1559,7 +1559,7 @@ namespace beam::wallet
     TxFailureReason CheckAssetsEnabled(Height h)
     {
         const Rules& r = Rules::get();
-        if (h < r.pForks[2].m_Height)
+        if (!r.IsPastFork(h, 2))
             return TxFailureReason::AssetsDisabledFork2;
 
         if (!r.CA.Enabled)
@@ -1569,16 +1569,6 @@ namespace beam::wallet
             return TxFailureReason::AssetsDisabledInWallet;
 
         return TxFailureReason::Count;
-    }
-
-    bool isFork3(Height h)
-    {
-        const Rules& r = Rules::get();
-        if (h < r.pForks[3].m_Height)
-        {
-            return false;
-        }
-        return true;
     }
 
     void AppendLibraryVersion(TxParameters& params)

--- a/wallet/core/common.cpp
+++ b/wallet/core/common.cpp
@@ -1559,7 +1559,7 @@ namespace beam::wallet
     TxFailureReason CheckAssetsEnabled(Height h)
     {
         const Rules& r = Rules::get();
-        if (!r.IsPastFork(h, 2))
+        if (!r.IsPastFork_<2>(h))
             return TxFailureReason::AssetsDisabledFork2;
 
         if (!r.CA.Enabled)

--- a/wallet/core/common.h
+++ b/wallet/core/common.h
@@ -825,7 +825,6 @@ namespace beam::wallet
 
     extern bool g_AssetsEnabled; // global flag
     TxFailureReason CheckAssetsEnabled(Height h);
-    bool isFork3(Height h);
 
     void AppendLibraryVersion(TxParameters& params);
 

--- a/wallet/core/contracts/shaders_manager.cpp
+++ b/wallet/core/contracts/shaders_manager.cpp
@@ -147,6 +147,26 @@ namespace beam::wallet {
         std::cout << std::endl;
     }
 
+    void ManagerStdInWallet::LoadVar(const Blob& key, Blob& res)
+    {
+        if (!m_Wallet.get_WalletDB()->get_AppData(key, m_LastVar))
+            m_LastVar.clear();
+        
+        res = m_LastVar;
+    }
+
+    void ManagerStdInWallet::LoadVarEx(Blob& key, Blob& res, bool /* bExact */, bool /* bBigger */)
+    {
+        // TODO
+        LoadVar(key, res);
+    }
+
+    uint32_t ManagerStdInWallet::SaveVar(const Blob& key, const Blob& val)
+    {
+        m_Wallet.get_WalletDB()->set_AppData(key, val.n ? &val : nullptr);
+        return 0;
+    }
+
     bvm2::ContractInvokeData ManagerStdInWallet::get_InvokeData()
     {
         bvm2::ContractInvokeData res;

--- a/wallet/core/contracts/shaders_manager.cpp
+++ b/wallet/core/contracts/shaders_manager.cpp
@@ -147,9 +147,14 @@ namespace beam::wallet {
         std::cout << std::endl;
     }
 
+    Blob ManagerStdInWallet::get_StoreName()
+    {
+        return Blob(); // empty
+    }
+
     void ManagerStdInWallet::LoadVar(const Blob& key, Blob& res)
     {
-        if (!m_Wallet.get_WalletDB()->get_AppData(key, m_LastVar))
+        if (!m_Wallet.get_WalletDB()->get_AppData(get_StoreName(), key, m_LastVar))
             m_LastVar.clear();
         
         res = m_LastVar;
@@ -163,7 +168,7 @@ namespace beam::wallet {
 
     uint32_t ManagerStdInWallet::SaveVar(const Blob& key, const Blob& val)
     {
-        m_Wallet.get_WalletDB()->set_AppData(key, val.n ? &val : nullptr);
+        m_Wallet.get_WalletDB()->set_AppData(get_StoreName(), key, val.n ? &val : nullptr);
         return 0;
     }
 

--- a/wallet/core/contracts/shaders_manager.h
+++ b/wallet/core/contracts/shaders_manager.h
@@ -50,6 +50,8 @@ namespace beam::wallet {
         void LoadVar(const Blob&, Blob& res) override;
         void LoadVarEx(Blob& key, Blob& res, bool bExact, bool bBigger) override;
         uint32_t SaveVar(const Blob&, const Blob& val) override;
+
+        virtual Blob get_StoreName();
     };
 
     class ShadersManager

--- a/wallet/core/contracts/shaders_manager.h
+++ b/wallet/core/contracts/shaders_manager.h
@@ -32,7 +32,8 @@ namespace beam::wallet {
     protected:
 
         Wallet& m_Wallet;
-        uint32_t m_Privilege;
+        uint32_t m_Privilege = 0;
+        ByteBuffer m_LastVar;
 
         struct SlotName;
         struct Channel;
@@ -45,6 +46,10 @@ namespace beam::wallet {
         void Comm_CreateListener(Comm::Channel::Ptr&, const ECC::Hash::Value&) override;
         void Comm_Send(const ECC::Point&, const Blob&) override;
         void WriteStream(const Blob&, uint32_t iStream) override;
+
+        void LoadVar(const Blob&, Blob& res) override;
+        void LoadVarEx(Blob& key, Blob& res, bool bExact, bool bBigger) override;
+        uint32_t SaveVar(const Blob&, const Blob& val) override;
     };
 
     class ShadersManager

--- a/wallet/core/wallet.cpp
+++ b/wallet/core/wallet.cpp
@@ -447,14 +447,11 @@ namespace beam::wallet
         if (x.empty())
         {
             m_WalletDB->ClearAppData(Blob(sName.c_str(), static_cast<uint32_t>(sName.size())));
-            m_WalletDB->removeVarRaw(WidgetRunner::s_szVarName);
         }
         else
         {
             Blob buf(x);
             m_WalletDB->set_AppData(Blob(sName.c_str(), static_cast<uint32_t>(sName.size())), Blob(), &buf);
-
-            m_WalletDB->setVarRaw(WidgetRunner::s_szVarName, &x.front(), x.size());
 
             w.GetOrCreate(*this, std::move(sName));
         }

--- a/wallet/core/wallet.h
+++ b/wallet/core/wallet.h
@@ -164,7 +164,7 @@ namespace beam::wallet
         void ResumeAllTransactions();
         void VisitActiveTransaction(const TxVisitor& visitor);
 
-        void SetWidget(ByteBuffer&&);
+        void SetWidget(std::string&&, ByteBuffer&&);
 
         bool IsWalletInSync() const;
         Height get_TipHeight() const;

--- a/wallet/core/wallet.h
+++ b/wallet/core/wallet.h
@@ -19,7 +19,7 @@
 #include "base_transaction.h"
 #include "core/fly_client.h"
 #include "node/processor.h"
-#include "../../bvm/ManagerStd.h"
+//#include "contracts/shaders_manager.h"
 
 namespace beam::wallet
 {
@@ -250,15 +250,9 @@ namespace beam::wallet
             IMPLEMENT_GET_PARENT_OBJ(Wallet, m_RequestHandler)
         } m_RequestHandler;
 
-        struct WidgetRunner
-            :public bvm2::ManagerStd
-        {
-            static const char s_szVarName[];
-            void WriteStream(const Blob&, uint32_t iStream) override;
-            void OnDone(const std::exception* pExc) override;
-
-            IMPLEMENT_GET_PARENT_OBJ(Wallet, m_WidgetRunner)
-        } m_WidgetRunner;
+        struct WidgetRunner;
+        std::unique_ptr<WidgetRunner> m_pWidgetRunner;
+        void InitWidgetRunner();
 
         size_t SyncRemains() const;
         size_t GetSyncDone() const;

--- a/wallet/core/wallet.h
+++ b/wallet/core/wallet.h
@@ -465,16 +465,38 @@ namespace beam::wallet
                     IMPLEMENT_GET_PARENT_OBJ(Request, m_Target)
                 } m_Target;
 
+                struct ListNode :public boost::intrusive::list_base_hook<>
+                {
+                    typedef boost::intrusive::list<ListNode> List;
+                    Timestamp m_ReqTime_s;
+                    IMPLEMENT_GET_PARENT_OBJ(Request, m_ListNode)
+                } m_ListNode;
+
                 WalletID m_OwnAddr;
+                ECC::Scalar::Native m_sk; // not so secret
             };
 
             Request::Target::Set m_setTrg;
+            Request::ListNode::List m_lstRequests;
+
+            io::Timer::Ptr m_pTimer;
 
             Request* CreateIfNew(const WalletID& trg);
             void Delete(Request&);
             void DeleteAll();
+            void Listen(Request&);
+            void SendRequest(Request&);
+            bool IsFirstDue(const Request&) const;
+
+            void CheckTimer();
+            void EnsureRequest(const WalletID& trg);
+
+            ByteBuffer SaveState() const;
+            void LoadState(const Blob&);
 
             ~VoucherManager() { DeleteAll(); }
+
+            struct Ser;
 
             IMPLEMENT_GET_PARENT_OBJ(Wallet, m_VoucherManager)
         } m_VoucherManager;

--- a/wallet/core/wallet_db.cpp
+++ b/wallet/core/wallet_db.cpp
@@ -112,6 +112,10 @@ namespace fs = std::filesystem;
 #define IM_NAME "IM"
 #define LAST_READ_IM_ID "LastReadIMId"
 
+#define TblAppData "appdata"
+#define TblAppData_Key "key"
+#define TblAppData_Val "val"
+
 #define ENUM_VARIABLES_FIELDS(each, sep, obj) \
     each(name,  name,  TEXT UNIQUE, obj) sep \
     each(value, value, BLOB, obj)
@@ -1020,7 +1024,8 @@ namespace beam::wallet
         const uint8_t kDefaultMaxPrivacyLockTimeLimitHours = 72;
         const int BusyTimeoutMs = 5000;
 
-        const int DbVersion   = 37;
+        const int DbVersion   = 38;
+        const int DbVersion37 = 37;
         const int DbVersion36 = 36;
         const int DbVersion35 = 35;
         const int DbVersion34 = 34;
@@ -1248,6 +1253,13 @@ namespace beam::wallet
             const char* req = "CREATE TABLE " STORAGE_NAME " (" ENUM_ALL_STORAGE_FIELDS(LIST_WITH_TYPES, COMMA, ) ");"
                 "CREATE UNIQUE INDEX CoinIndex ON " STORAGE_NAME "(" ENUM_STORAGE_ID(LIST, COMMA, )  ");"
                 "CREATE INDEX ConfirmIndex ON " STORAGE_NAME"(confirmHeight);";
+            int ret = sqlite3_exec(db, req, nullptr, nullptr, nullptr);
+            throwIfError(ret, db);
+        }
+
+        void CreateAppDataTable(sqlite3* db)
+        {
+            const char* req = "CREATE TABLE " TblAppData " (" TblAppData_Key " BLOB NOT NULL PRIMARY KEY, " TblAppData_Val " BLOB NOT NULL );";
             int ret = sqlite3_exec(db, req, nullptr, nullptr, nullptr);
             throwIfError(ret, db);
         }
@@ -1920,6 +1932,7 @@ namespace beam::wallet
         CreateVerificationTable(db);
         CreateDexOffersTable(db);
         CreateIMTables(db);
+        CreateAppDataTable(db);
     }
 
     std::shared_ptr<WalletDB> WalletDB::initBase(const string& path, const SecString& password, bool separateDBForPrivateData)
@@ -2488,10 +2501,16 @@ namespace beam::wallet
                     CreateIMTables(walletDB->_db);
                     // no break
 
+                case DbVersion37:
+                    BEAM_LOG_INFO() << "Converting DB from format 37...";
+
+                    CreateTxParamsIndex(walletDB->_db);
+                    CreateAppDataTable(walletDB->_db);
+
                     storage::setVar(*walletDB, Version, DbVersion);
+                    // no break
 
                 case DbVersion:
-                    CreateTxParamsIndex(walletDB->_db);
                     // drop private variables from public database for cold wallet
                     if (separateDBForPrivateData && !DropPrivateVariablesFromPublicDatabase(*walletDB))
                     {
@@ -6056,6 +6075,50 @@ namespace beam::wallet
         const char* req = "DELETE FROM " TblStates " WHERE " TblStates_Height ">=?";
         sqlite::Statement stm(&get_ParentObj(), req);
         stm.bind(1, h);
+        stm.step();
+    }
+
+    bool WalletDB::get_AppData(const Blob& key, ByteBuffer& res)
+    {
+        const char* req = "SELECT " TblAppData_Val " FROM " TblAppData " WHERE " TblAppData_Key "=?";
+
+        sqlite::Statement stm(this, req);
+        stm.bind(1, key);
+
+        if (!stm.step())
+            return false;
+
+        stm.get(0, res);
+        return true;
+
+    }
+
+    void WalletDB::set_AppData(const Blob& key, const Blob* pRes)
+    {
+        if (pRes)
+        {
+            const char* req = "INSERT or REPLACE INTO " TblAppData " (" TblAppData_Key "," TblAppData_Val ") VALUES(?1, ?2);";
+
+            sqlite::Statement stm(this, req);
+
+            stm.bind(1, key);
+            stm.bind(2, *pRes);
+
+            stm.step();
+        }
+        else
+        {
+            const char* req = "DELETE FROM " TblAppData " WHERE " TblAppData_Key "=?";
+            sqlite::Statement stm(this, req);
+            stm.bind(1, key);
+            stm.step();
+        }
+    }
+
+    void WalletDB::ClearAppData()
+    {
+        const char* req = "DELETE FROM " TblAppData;
+        sqlite::Statement stm(this, req);
         stm.step();
     }
 

--- a/wallet/core/wallet_db.h
+++ b/wallet/core/wallet_db.h
@@ -649,9 +649,9 @@ namespace beam::wallet
         virtual void visitEvents(Height min, std::function<bool(Height, ByteBuffer&&)>&& func) const = 0;
 
         // app data
-        virtual bool get_AppData(const Blob&, ByteBuffer&) { return false; }
-        virtual void set_AppData(const Blob&, const Blob*) {}
-        virtual void ClearAppData() {}
+        virtual bool get_AppData(const Blob& name, const Blob&, ByteBuffer&) { return false; }
+        virtual void set_AppData(const Blob& name, const Blob&, const Blob*) {}
+        virtual void ClearAppData(const Blob& name) {}
 
        private:
            bool get_CommitmentSafe(ECC::Point& comm, const CoinID&, IPrivateKeyKeeper2*);
@@ -827,9 +827,9 @@ namespace beam::wallet
         void visitEvents(Height min, const Blob& key, std::function<bool(Height, ByteBuffer&&)>&& func) const override;
         void visitEvents(Height min, std::function<bool(Height, ByteBuffer&&)>&& func) const override;
 
-        bool get_AppData(const Blob&, ByteBuffer&) override;
-        void set_AppData(const Blob&, const Blob*) override;
-        void ClearAppData() override;
+        bool get_AppData(const Blob& name, const Blob&, ByteBuffer&) override;
+        void set_AppData(const Blob& name, const Blob&, const Blob*) override;
+        void ClearAppData(const Blob& name) override;
 
     private:
         static std::shared_ptr<WalletDB> initBase(const std::string& path, const SecString& password, bool separateDBForPrivateData);

--- a/wallet/core/wallet_db.h
+++ b/wallet/core/wallet_db.h
@@ -648,6 +648,11 @@ namespace beam::wallet
         virtual void visitEvents(Height min, const Blob& key, std::function<bool(Height, ByteBuffer&&)>&& func) const = 0;
         virtual void visitEvents(Height min, std::function<bool(Height, ByteBuffer&&)>&& func) const = 0;
 
+        // app data
+        virtual bool get_AppData(const Blob&, ByteBuffer&) { return false; }
+        virtual void set_AppData(const Blob&, const Blob*) {}
+        virtual void ClearAppData() {}
+
        private:
            bool get_CommitmentSafe(ECC::Point& comm, const CoinID&, IPrivateKeyKeeper2*);
     };
@@ -821,6 +826,10 @@ namespace beam::wallet
         void deleteEventsFrom(Height h) override;
         void visitEvents(Height min, const Blob& key, std::function<bool(Height, ByteBuffer&&)>&& func) const override;
         void visitEvents(Height min, std::function<bool(Height, ByteBuffer&&)>&& func) const override;
+
+        bool get_AppData(const Blob&, ByteBuffer&) override;
+        void set_AppData(const Blob&, const Blob*) override;
+        void ClearAppData() override;
 
     private:
         static std::shared_ptr<WalletDB> initBase(const std::string& path, const SecString& password, bool separateDBForPrivateData);

--- a/wallet/transactions/assets/aunregister_transaction.cpp
+++ b/wallet/transactions/assets/aunregister_transaction.cpp
@@ -45,7 +45,7 @@ namespace beam::wallet
             std::unique_ptr<TxKernelAssetDestroy> pKrn = std::make_unique<TxKernelAssetDestroy>();
             pKrn->m_AssetID = m_Tx.GetMandatoryParameter<Asset::ID>(TxParameterID::AssetID);
 
-            if (m_Height.m_Min >= Rules::get().pForks[5].m_Height)
+            if (Rules::get().IsPastFork(m_Height.m_Min, 5))
                 pKrn->m_Deposit = valDeposit;
 
             AddKernel(std::move(pKrn));

--- a/wallet/transactions/assets/aunregister_transaction.cpp
+++ b/wallet/transactions/assets/aunregister_transaction.cpp
@@ -45,7 +45,7 @@ namespace beam::wallet
             std::unique_ptr<TxKernelAssetDestroy> pKrn = std::make_unique<TxKernelAssetDestroy>();
             pKrn->m_AssetID = m_Tx.GetMandatoryParameter<Asset::ID>(TxParameterID::AssetID);
 
-            if (Rules::get().IsPastFork(m_Height.m_Min, 5))
+            if (Rules::get().IsPastFork_<5>(m_Height.m_Min))
                 pKrn->m_Deposit = valDeposit;
 
             AddKernel(std::move(pKrn));


### PR DESCRIPTION
Updated on v0.4:
- Multiple contract calls are now displayed in groups, with one single block height for all.
- Sorting and filtering has been adapted to work with such groups of rows.
- Table headers are now sticky to the top of the window.
- Column widths keep a similar width when their filters are activated.
- Ascending/descending symbols have been inverted (to use same logic as Wikipedia tables).
- Detection of some Confidential Asset metadata, for better styling.
- Hashes and metadata are now displayed truncated, with individual eye symbols to expand them.
- An eye symbol has been added to the banner, to expand/truncate everything at once.
- Removed the small collapsibles for metadata (since they now have the eye symbol instead)
- The node asset list request does not need the block height anymore (as default is current block height).
- Made the main navigation links permanent by moving them into the banner.
- Reduced top banner height (better for in-wallet display).
- Added introductory comments in code (intro, guidelines, version) and separation in four sections.
- Added noscript warning.
- Added some header elements which are also used in to other Beam DApps.
- Added embedded SVG favicon (compact version of Beam logo)
- Header and footer are now static HTML, displayed right away before loading the main content.
- Added scroll up/down floating buttons.
- Added nMax in URL for contract calls and block headers (will be made user-modifiable later on)
- Added arrows around block heights in titles to navigate to older/newer block heights.
- Added a 'list' symbol before the block page title with a link to the block headers list.
- Replaced 'MakeMoreLink' with 'MakeLinkToOlderBlocks' (in preparation for a future smarter 'MakeLinkToNewerBlocks' that will also allow navigating pages forward).
- Adjusted font-family for monospace
- Replaced \\" with '
- Added tool-tips in many places.
- Timestamps are now colored.
- Amounts can have 3 colors (unsigned, positive, negative)
- 'hdrs' request now explicits the requested columns (will be used later on to allow user-selection).
- Made a few adjustments to be compatible with Chrome 83 (to allow running as Beam Wallet DApp).
- Made all header row cells 'th' instead of 'td' (needed to make them sticky on Chrome 83).
- Some other small style adjustments across the code.