### PR TITLE
Remove help print on error

### DIFF
--- a/beam/cli.cpp
+++ b/beam/cli.cpp
@@ -290,7 +290,6 @@ int main(int argc, char* argv[])
 		catch (const po::error& e)
 		{
 			cout << e.what() << std::endl;
-			printHelp(visibleOptions);
 
 			return 0;
 		}
@@ -648,7 +647,6 @@ int main(int argc, char* argv[])
 		catch (const po::error& e)
 		{
 			BEAM_LOG_ERROR() << e.what();
-			printHelp(visibleOptions);
 		}
 		catch (const std::runtime_error& e)
 		{

--- a/explorer/explorer_node.cpp
+++ b/explorer/explorer_node.cpp
@@ -214,8 +214,7 @@ bool parse_cmdline(int argc, char* argv[], Options& o) {
     }
     catch (const po::error& ex)
     {
-        cout << ex.what();
-        cout << cliOptions << std::endl;
+        cout << ex.what() << std::endl;
     }
     catch (const exception& ex)
     {

--- a/wallet/cli/cli.cpp
+++ b/wallet/cli/cli.cpp
@@ -3414,7 +3414,6 @@ int main(int argc, char* argv[])
         catch (const po::error& e)
         {
             cout << e.what() << std::endl;
-            printHelp(begin(commands), end(commands), visibleOptions);
 
             return 0;
         }
@@ -3467,7 +3466,6 @@ int main(int argc, char* argv[])
                 if (vm.count(cli::COMMAND) == 0)
                 {
                     BEAM_LOG_ERROR() << kErrorCommandNotSpecified;
-                    printHelp(begin(commands), end(commands), visibleOptions);
                     return 0;
                 }
 
@@ -3520,7 +3518,6 @@ int main(int argc, char* argv[])
         catch (const po::error& e)
         {
             BEAM_LOG_ERROR() << e.what();
-            printHelp(begin(commands), end(commands), visibleOptions);
         }
         catch (const std::runtime_error& e)
         {


### PR DESCRIPTION
*Why?*
When launching the wallet/node/explorer node with incorrect arguments, it prints the error plus _all_ CLI options.
This makes it hard to make out what the issue was, because the error message will be hidden at the top.

This stops printing CLI options when an error occurs on launch and only shows the error.
CLI options are still accessible with the ```./beam-node help``` command.