### PR TITLE
Explorer HTML v0.8: Handle multiple networks and explorer nodes

### DIFF
--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -5,11 +5,11 @@
 
   <!-- WELCOME TO BEAM SMART EXPLORER!
   - This is an interactive web display of the data queried to a Beam explorer node.
-  - The IP address of the explorer node can be changed in var 'urlPrefix'.
+  - The IP addresses of the authorized explorer nodes can be changed in variable 'explorerNodes'.
   - Current version of the file: v0.8
 
   General rules for developement:
-  - Let's keep everything in one single standalone file!
+  - Let's keep everything in one single standalone file, without external dependencies!
   - Vanilla HTML/JS/CSS compatible with Chrome 83 (to allow using it as a Beam Wallet DApp).
   - Graphics are embedded as SVG or are Unicode symbols.
   - Except for filtering and sorting, JS functions shall mainly modify classes while most display features are done by CSS.
@@ -40,7 +40,7 @@
 
   <!-- ************ SECTION 1 - MAIN GLOBAL VARIABLES ************ -->
 <script>
-  "use strict"; // Forces safer JavaScript code (e.g. forbids using undeclared variables, etc.).
+  "use strict"; // Force safer JavaScript code (e.g. forbids using undeclared variables, etc.).
 
   // Check localStorage for light/dark mode status ("light" or "")
   let mode = localStorage.getItem('mode');
@@ -77,9 +77,20 @@
     height: 100%; /* Copied from the DEX dApp */
     scroll-behavior: smooth;
   }
+  body:has(dialog:modal) { overflow: hidden; } /* Blocks scrolling when dialog is on (but doesn't work in Chrome 83) */
   :root {
+    /* BEAM reference colors */
+    --color-mauve: #9d6eff;
+    --color-violet: #ab37e6;
+    --color-pink: #fe52ff;
+    --color-green: #00e2c2;
+    --color-cyan: #39fff2;
+    --color-light-blue: #25c1ff;
+    --color-blue: #0b76ff;
+    --color-white: #ffffff;
+    --color-black: #000000;
     /* Color variables for dark mode (default) */
-    color-scheme: dark; /* For elements (if any) without an explicit style */
+    color-scheme: dark; /* For browser elements without an explicit style */
     --color_background: #042548;
     --color_background_gradient_top: #035b8f;
     --color_background_gradient_main: #042548;
@@ -92,7 +103,7 @@
     --color_h3_sub: #17204e;
     --color_link: #0066CC;
     --color_link_visited: #3e1a8b;
-    --color_node_url: #00e2c2;
+    --color_node_url: var(--color-green);
     --color_blockheight_title_link: #65a4e3;
     --color_blockheight_title_link_visited: #a17eec;
     --color_metadata: #505050;
@@ -127,7 +138,7 @@
     --color_popup_border: #ddd;
     --color_popup_background: #042548;
     --color_popup_text : #ddd;
-    --color_popup_url : #00e2c2;
+    --color_popup_url : var(--color-green);
     --color_popup_input_placeholder: #aaa;
     --color_popup_input_text: #eee;
     --color_popup_input_text_invalid: #ff8686;
@@ -202,8 +213,18 @@
     --color_table_search_background_filled: #1d3a5a;
   }
   :root.light {
+    /* BEAM reference colors */
+    --color-mauve: #9d6eff;
+    --color-violet: #ab37e6;
+    --color-pink: #fe52ff;
+    --color-green: #00e2c2;
+    --color-cyan: #39fff2;
+    --color-light-blue: #25c1ff;
+    --color-blue: #0b76ff;
+    --color-white: #ffffff;
+    --color-black: #000000;
     /* Color variables for light mode */
-    color-scheme: light; /* For elements (if any) without an explicit style */
+    color-scheme: light; /* For browser elements without an explicit style */
     --color_background: #d0daff;
     --color_background_gradient_top: #d0daff;
     --color_background_gradient_main: #d0daff;
@@ -1210,7 +1231,6 @@
   /* SPECIAL OPTIONS FOR BLOCK HEADERS TABLE */
   /* (the Block Headers table has hidden description and drag and drop items) */
   #selectCurrentColumns, #selectDefaultColumns, #selectAllColumns, #pasteColumns, #reorderAllColumns {} /* Columns selection links */
-  body:has(dialog:modal) { overflow: hidden; } /* Blocks scrolling when dialog is on (but doesn't work in Chrome 83) */
   #pasteColumnsPopup { /* Dialog popup */
     border: solid 5px var(--color_popup_border);
     border-radius: 1rem;
@@ -2369,8 +2389,7 @@
     defineDraggableElements(); // Make checkboxes draggable
   }
 
-  // Display an 'ABOUT' block
-  function AboutSection() {
+  function AboutSection() { // Display an 'ABOUT' block
     let text = "<div class='about'>\n";
     text += "<h2 class='title'>About</h2>\n";
     text += "<p class='aboutText'>";
@@ -2390,8 +2409,8 @@
     text += "<p class='aboutText'>";
     text += "This app is an interactive web display of the data queried to a Beam explorer node \
             (selected from a <a href='javascript:openNodeSelection();' title='Show list of explorer nodes'>predefined list</a>).\
-            The whole interface is held in <b>one single HTML file</b>, written in vanilla HTML/JS/CSS and with no external dependencies. \
-            You can save the HTML file and simply open it locally in your browser! Source is also available on <a href='https://github.com/BeamMW/beam/tree/master/explorer/htm' target='_blank'>Github</a>.";
+            The whole thing is held in <b>one single HTML file</b>, written in vanilla HTML/JS/CSS and with no external dependencies. \
+            You can see and save the <a href='view-source:" + window.location.href.split('?')[0] + "' target='_blank'>source HTML</a> file using CTRL-U or CMD-U, and then simply open it locally with any modern browser. The source code is also available on <a href='https://github.com/BeamMW/beam/blob/master/explorer/htm/BeamExplorer.htm' target='_blank'>Github</a>.";
     text += "</p>\n";
     text += "<p class='aboutDisclaimer'>";
     text += "Disclaimer: This is an experimental work-in-progress. It is provided AS-IS, with no warranties whatsoever.";
@@ -2443,7 +2462,7 @@
   }
 
   function DisplayHistoricalBlocks() {
-    let text = "<h2 class='title'>Special historical blocks</h2>";
+    let text = "<h2 class='title'>Special historical blocks in Beam's mainnet</h2>";
     text += "\
       <table class='tableHistoricalBlocks'>\n\
         <thead><tr>\n\
@@ -2535,7 +2554,7 @@
     {
       block_list: [0],
       title: 'Treasury',
-      description: "Beam emission schedule is inspired by Bitcoin's, but with 10 times more blocks (1 block per minute). The first halving occured after 1 year, and the following ones every 4 years. The total supply is 262,800,000 Beam. <b>For the first 5 years, 20% of the block rewards were sent to a Treasury</b>, that the <b>Beam Foundation</b> used to repay investors and fund development.<br>This <a href='?type=treasury' title='Treasury'>Treasury</a> is also represented in the explorer as a <a href='?type=block&height=0' title='Treasury as block height 0'>pseudo-block at height 0</a>, that contains pre-allocated UTXOs. Each UTXO corresponds to a particular allocation, and has an appropriate 'maturity' (which is the block height after which it can be spent). As usual, UTXOs amounts and their owners are concealed. However those UTXOs are arranged in groups of identical validity, and the blockchain source code contains a proof that allows verifying the total value of the group. That way, it's possible to verify how much value was released at each height. Since the treasury plan lasted 5 years, with UTXOs maturing each month (i.e. every 43,800 blocks), we can see <a href='?type=treasury' title='List Treasury UTXOs'>60 such groups</a>.",
+      description: "Beam emission schedule is inspired by Bitcoin's, but with 10 times more blocks (1 block per minute). The first halving occured after 1 year, and the following ones every 4 years. The total supply is 262,800,000 Beam. <b>For the first 5 years, 20% of the block rewards were sent to a Treasury</b>, that the <b>Beam Foundation</b> used to repay investors and fund development.<br>This <a href='?network=mainnet&type=treasury' title='Treasury'>Treasury</a> is also represented in the explorer as a <a href='?network=mainnet&type=block&height=0' title='Treasury as block height 0'>pseudo-block at height 0</a>, that contains pre-allocated UTXOs. Each UTXO corresponds to a particular allocation, and has an appropriate 'maturity' (which is the block height after which it can be spent). As usual, UTXOs amounts and their owners are concealed. However those UTXOs are arranged in groups of identical validity, and the blockchain source code contains a proof that allows verifying the total value of the group. That way, it's possible to verify how much value was released at each height. Since the treasury plan lasted 5 years, with UTXOs maturing each month (i.e. every 43,800 blocks), we can see <a href='?network=mainnet&type=treasury' title='List Treasury UTXOs'>60 such groups</a>.",
       links: [
         ['Beam emission schedule', 'https://medium.com/beam-mw/mimblewimble-emission-schedule-215551948259'],
         ['Beam Foundation', 'https://www.beam-foundation.org'],
@@ -2545,7 +2564,7 @@
     {
       block_list: [1],
       title: 'Genesis block',
-      description: "The Beam project started in March 2018 and the first medium post introducing Beam to the world was published on July 19<sup>th</sup> 2018 (exactly two years after the original MimbleWimble paper was published!). After nine and a half months of development, <b>Beam launched the first ever MimbleWimble-based confidential cryptocurrency</b> on <a href='?type=block&height=1' title='Genesis block'>January 3<sup>rd</sup> 2019</a> (which was also the 10-year anniversary of Bitcoin genesis block!). There was no pre-mine nor ICO, and the Beam mainnet launched with 0 coins in existence (to prove that there was no pre-mine, Beam's genesis block lists the hash of Bitcoin's block 556833, mined on 2019–01–03 12:46:37 GMT, as previous block hash).",
+      description: "The Beam project started in March 2018 and the first medium post introducing Beam to the world was published on July 19<sup>th</sup> 2018 (exactly two years after the original MimbleWimble paper was published!). After nine and a half months of development, <b>Beam launched the first ever MimbleWimble-based confidential cryptocurrency</b> on <a href='?network=mainnet&type=block&height=1' title='Genesis block'>January 3<sup>rd</sup> 2019</a> (which was also the 10-year anniversary of Bitcoin genesis block!). There was no pre-mine nor ICO, and the Beam mainnet launched with 0 coins in existence (to prove that there was no pre-mine, Beam's genesis block lists the hash of Bitcoin's block 556833, mined on 2019–01–03 12:46:37 GMT, as previous block hash).",
       links: [
         ['Original MimbleWimble paper', 'https://download.wpsoftware.net/bitcoin/wizardry/mimblewimble.txt'],
         ['First Beam Medium post', 'https://medium.com/beam-mw/introducing-beam-f35096a923ec'],
@@ -2557,19 +2576,19 @@
     {
       block_list: [159, 160],
       title: 'The fastest blocks on Earth',
-      description: "On January 3<sup>rd</sup> 2019, about one hour and half after the genesis block, a rare event occured: the <a href='?type=hdrs&cols=THkioyz&hMax=160&nMax=8'>two consecutive blocks 159 and 160</a> were mined <b>within the same second!</b> A similar event will occure again a few times after that (example with <a href='?type=hdrs&cols=THkioyz&hMax=25709&nMax=8'>blocks 25708 and 25709</a>). Indeed, the event is possible, but quite unlikely. Neglecting all other factors (like the time needed to assemble a block, or the minimal cycle time for a single PoW solution search) and considering that the mining process has a Poisson distribution, then the probability to mine a block in 1 second is 1-e^(-1/60) = 0.016. However, this particular case could also be due to block times being inaccurate, or to different miners having deviations in their time settings. Because small deviations are effectively allowed. It is even explicitely allowed to have time stamps coming in reverse order...",
+      description: "On January 3<sup>rd</sup> 2019, about one hour and half after the genesis block, a rare event occured: the <a href='?network=mainnet&type=hdrs&cols=THkioyz&hMax=160&nMax=8'>two consecutive blocks 159 and 160</a> were mined <b>within the same second!</b> A similar event will occure again a few times after that (example with <a href='?network=mainnet&type=hdrs&cols=THkioyz&hMax=25709&nMax=8'>blocks 25708 and 25709</a>). Indeed, the event is possible, but quite unlikely. Neglecting all other factors (like the time needed to assemble a block, or the minimal cycle time for a single PoW solution search) and considering that the mining process has a Poisson distribution, then the probability to mine a block in 1 second is 1-e^(-1/60) = 0.016. However, this particular case could also be due to block times being inaccurate, or to different miners having deviations in their time settings. Because small deviations are effectively allowed. It is even explicitely allowed to have time stamps coming in reverse order...",
       links: [['Poisson distribution', 'https://en.wikipedia.org/wiki/Poisson_distribution']]
     },
     {
       block_range: [25709, 25820],
       title: 'Blockchain Stop Event',
-      description: "On January 21<sup>st</sup> 2019, the Beam blockchain stopped producing blocks at <a href='?type=hdrs&cols=THkioyz&hMax=25711&nMax=6'>block 25709</a>. Beam developers immediately looked into it and released a hot fix a few hours later. No blocks were produced <a href='?type=hdrs&cols=THkioyz&hMax=25711&nMax=6'>for 2.5 hours</a>, and no transactions (except for the coinbase) were processed for <a href='?type=hdrs&cols=THkioyz&hMax=25822&nMax=120' title='Block headers over the whole period'>112 blocks</a>, until blocks <a href='?type=block&height=25820'>25820</a> and <a href='?type=block&height=25822'>25822</a> processed all the pending ones. No funds were lost.",
+      description: "On January 21<sup>st</sup> 2019, the Beam blockchain stopped producing blocks at <a href='?network=mainnet&type=hdrs&cols=THkioyz&hMax=25711&nMax=6'>block 25709</a>. Beam developers immediately looked into it and released a hot fix a few hours later. No blocks were produced <a href='?network=mainnet&type=hdrs&cols=THkioyz&hMax=25711&nMax=6'>for 2.5 hours</a>, and no transactions (except for the coinbase) were processed for <a href='?network=mainnet&type=hdrs&cols=THkioyz&hMax=25822&nMax=120' title='Block headers over the whole period'>112 blocks</a>, until blocks <a href='?network=mainnet&type=block&height=25820'>25820</a> and <a href='?network=mainnet&type=block&height=25822'>25822</a> processed all the pending ones. No funds were lost.",
       links: [['Postmortem analysis', 'https://medium.com/beam-mw/mimblewimble-blockchain-stop-event-postmortem-21012019-9a7ef38b2813']]
     },
     {
       block_list: [321321],
       title: 'First Hard-Fork',
-      description: "Beam's first hard-fork was performed as announced in the roadmap. The PoW algorithm was updated from <b>BeamHash I</b> to <b>BeamHash II</b>, which are upgrades from the vanilla Equihash on which they are based. Beam's strategy with these planned changes of the mining algorithm was to give GPU miners a head start, and then allow cheap ASICs to join in without disrupting the mining ecosystem.<br>After this hard-fork, a drop in block difficulty was observed as not all miners performed a timely upgrade. However, after <a href='?type=hdrs&cols=THdkioyz&hMax=322327&nMax=1010' title='Block headers of the 17 hours after the hard-fork'>less than 24 hours</a>, the block difficulty had gone back to its pre-fork value.",
+      description: "Beam's first hard-fork was performed as announced in the roadmap. The PoW algorithm was updated from <b>BeamHash I</b> to <b>BeamHash II</b>, which are upgrades from the vanilla Equihash on which they are based. Beam's strategy with these planned changes of the mining algorithm was to give GPU miners a head start, and then allow cheap ASICs to join in without disrupting the mining ecosystem.<br>After this hard-fork, a drop in block difficulty was observed as not all miners performed a timely upgrade. However, after <a href='?network=mainnet&type=hdrs&cols=THdkioyz&hMax=322327&nMax=1010' title='Block headers of the 17 hours after the hard-fork'>less than 24 hours</a>, the block difficulty had gone back to its pre-fork value.",
       links: [['Medium post', 'https://medium.com/beam-mw/mimblewimble-hard-fork-first-completed-1171f9642e51']]
     },
     {
@@ -2581,7 +2600,7 @@
     {
       block_list: [777777],
       title: 'Second Hard-Fork',
-      description: "Beam's second hard-fork was performed as announced in the roadmap. The PoW algorithm was updated from <b>BeamHash II</b> to <b>BeamHash III</b>, which is the final version in the planned strategy to balance GPU and ASIC mining. This hard-fork also saw the activation of the <a href='?type=assets'><b>Confidential Assets</b></a> (sometimes also called 'Privacy Tokens', and which were introduced in the first hard-fork but kept inactive) and the release of the <b>Lelantus-MW protocol</b> and its associated <b>one-side payments</b> (also known as <b>offline transactions</b>).",
+      description: "Beam's second hard-fork was performed as announced in the roadmap. The PoW algorithm was updated from <b>BeamHash II</b> to <b>BeamHash III</b>, which is the final version in the planned strategy to balance GPU and ASIC mining. This hard-fork also saw the activation of the <a href='?network=mainnet&type=assets'><b>Confidential Assets</b></a> (sometimes also called 'Privacy Tokens', and which were introduced in the first hard-fork but kept inactive) and the release of the <b>Lelantus-MW protocol</b> and its associated <b>one-side payments</b> (also known as <b>offline transactions</b>).",
       links: [
         ['Medium post', 'https://medium.com/beam-mw/hard-fork-completed-72e8f1edb10b'],
         ['BeamHash III presentation', 'https://docs.beam.mw/Beam_Hash_III_Slides.pdf'],
@@ -2600,13 +2619,13 @@
     {
       block_list: [778857],
       title: 'First input UTXO from a Shielded Pool',
-      description: "After a few transactions filling the <b>Lelantus Shielded Pool</b> with UTXOs, block <a href='?type=block&height=778857' title='Block details'>778857</a> saw the first use of one of these UTXOs as an input to a normal MimbleWimble transaction. We cannot know which one of the shielded UTXOs it was. However, as can be seen in the <a href='?type=block&height=778857' title='Block details'>block details</a>, the Shielded Pool at the time only contained 8 UTXOs, so its anonymity set was still quite low. Now, as the UTXOs from the Shielded Pool are never removed from the blockchain (there is no 'cut-through' for them, contrary to the MimbleWimble ones), its anonymity set keeps increasing linearly as people use Lelantus transactions. The current anonymity set is thus the total number of Shielded outputs produced up until now (as given in the <a href='?'>Blockchain Status</a>).",
+      description: "After a few transactions filling the <b>Lelantus Shielded Pool</b> with UTXOs, block <a href='?network=mainnet&type=block&height=778857' title='Block details'>778857</a> saw the first use of one of these UTXOs as an input to a normal MimbleWimble transaction. We cannot know which one of the shielded UTXOs it was. However, as can be seen in the <a href='?network=mainnet&type=block&height=778857' title='Block details'>block details</a>, the Shielded Pool at the time only contained 8 UTXOs, so its anonymity set was still quite low. Now, as the UTXOs from the Shielded Pool are never removed from the blockchain (there is no 'cut-through' for them, contrary to the MimbleWimble ones), its anonymity set keeps increasing linearly as people use Lelantus transactions. The current anonymity set is thus the total number of Shielded outputs produced up until now (as given in the <a href='?network=mainnet&'>Blockchain Status</a>).",
       links: null
     },
     {
       block_list: [780219],
       title: 'Creation of the first Confidential Asset',
-      description: "Two days after the second hard-fork, the <b>first Confidential Asset (with id:1)</b> was <a href='?type=block&height=780219'>created</a>. Although it has changed named since then, and seems to be <a href='?type=asset&id=1'>inactive today</a>, this first Confidential Asset was actually a draft for the subsequent <a href='?type=asset&id=9'>Tico coin (id:9)</a> which has been quite successful as <b>the first confidential meme coin</b>, with its fair, fun and feathered initial distribution!<br>As can be seen in the <a href='?type=block&height=2893306' title='Example in block 2893306'>block details</a> of any block, the transactions of confidential assets are as private as Beam transactions (i.e. no amount and no addresses are visible), and the wallet submitting the transaction can even make them undistinguishable from Beam transactions themselves (the id of the transacted asset being shown as belonging to a [0-63] range, with id:0 being Beam itself)!<br>As of today, <a href='?type=assets'>several confidential assets</a> have been created (including the 'AMML' ones, created by the DEX smart contract to represent the shares of its Liquidity Pools). Confidential assets have an <b>unlimited supply</b> when created through CLI (the owner wallet or contract can mint as many as needed), or a <b>hard-capped max supply</b> when created through the <a href='?type=contract&id=295fe749dc12c55213d1bd16ced174dc8780c020f59cb17749e900bb0c15d868' title='Smart contract call history'>Beam Asset Minter</a>.",
+      description: "Two days after the second hard-fork, the <b>first Confidential Asset (with id:1)</b> was <a href='?network=mainnet&type=block&height=780219'>created</a>. Although it has changed named since then, and seems to be <a href='?network=mainnet&type=asset&id=1'>inactive today</a>, this first Confidential Asset was actually a draft for the subsequent <a href='?network=mainnet&type=asset&id=9'>Tico coin (id:9)</a> which has been quite successful as <b>the first confidential meme coin</b>, with its fair, fun and feathered initial distribution!<br>As can be seen in the <a href='?network=mainnet&type=block&height=2893306' title='Example in block 2893306'>block details</a> of any block, the transactions of confidential assets are as private as Beam transactions (i.e. no amount and no addresses are visible), and the wallet submitting the transaction can even make them undistinguishable from Beam transactions themselves (the id of the transacted asset being shown as belonging to a [0-63] range, with id:0 being Beam itself)!<br>As of today, <a href='?network=mainnet&type=assets'>several confidential assets</a> have been created (including the 'AMML' ones, created by the DEX smart contract to represent the shares of its Liquidity Pools). Confidential assets have an <b>unlimited supply</b> when created through CLI (the owner wallet or contract can mint as many as needed), or a <b>hard-capped max supply</b> when created through the <a href='?network=mainnet&type=contract&id=295fe749dc12c55213d1bd16ced174dc8780c020f59cb17749e900bb0c15d868' title='Smart contract call history'>Beam Asset Minter</a>.",
       links: [
         //["Tico website","https://www.ticotip.me"],
         ["Tico's first anniversary", 'https://ticotipme.substack.com/p/tico-turns-1'],
@@ -2616,7 +2635,7 @@
     {
       block_list: [1280000],
       title: 'Third Hard-Fork (and wallet v6.0)',
-      description: "This hard-fork brought the addition of the <b>Beam Virtual Machine (BVM)</b> as an infrastructure to create <b>Smart Contracts</b> (a.k.a. 'Shaders'), thus making Beam <b>the first privacy coin with smart contracts capabilities!</b><br>BVM smart contracts can be written in any WebAssembly compatible language (such as C++, Rust, Go, etc.) and are composed of two elements: the blockchain side (running on Beam nodes) and the wallet side (running in Beam wallet, together with the DApp front ends). This separation of chain-side and client-side logics allows very powerful and flexible applications.<br>Beam smart contracts are <b>transparent by default</b>, which means that <a href='?type=contracts'>we can see their state and their activity</a>. Nevertheless, <b>the users remain anonymous</b>, as their interactions with the smart contracts are based on normal confidential Beam transactions. With this approach, Beam's DeFi manages to provide 'efficient' markets (e.g. where we can see what is bought and sold) while still protection its users' privacy (e.g. we cannot see who buys and sells!).<br>By allowing such <b>privacy-preserving smart contract capabilities</b>, this hard-fork opened the doors to Beam becoming not only <b>a powerful 'Privacy DeFi' (PriFi) platform</b> but indeed a general-purpose <b>infrastructure for anything in Confidential Web3</b>!",
+      description: "This hard-fork brought the addition of the <b>Beam Virtual Machine (BVM)</b> as an infrastructure to create <b>Smart Contracts</b> (a.k.a. 'Shaders'), thus making Beam <b>the first privacy coin with smart contracts capabilities!</b><br>BVM smart contracts can be written in any WebAssembly compatible language (such as C++, Rust, Go, etc.) and are composed of two elements: the blockchain side (running on Beam nodes) and the wallet side (running in Beam wallet, together with the DApp front ends). This separation of chain-side and client-side logics allows very powerful and flexible applications.<br>Beam smart contracts are <b>transparent by default</b>, which means that <a href='?network=mainnet&type=contracts'>we can see their state and their activity</a>. Nevertheless, <b>the users remain anonymous</b>, as their interactions with the smart contracts are based on normal confidential Beam transactions. With this approach, Beam's DeFi manages to provide 'efficient' markets (e.g. where we can see what is bought and sold) while still protection its users' privacy (e.g. we cannot see who buys and sells!).<br>By allowing such <b>privacy-preserving smart contract capabilities</b>, this hard-fork opened the doors to Beam becoming not only <b>a powerful 'Privacy DeFi' (PriFi) platform</b> but indeed a general-purpose <b>infrastructure for anything in Confidential Web3</b>!",
       links: [
         ['Medium post', 'https://medium.com/beam-mw/hard-fork-completed-1608eb5ce439'],
         ['Beam smart contracts introduction', 'https://github.com/BeamMW/shader-sdk/wiki/Beam-Smart-Contracts'],
@@ -2627,13 +2646,13 @@
     {
       block_list: [1280003],
       title: 'Deployment of the first Smart Contract',
-      description: "A few minutes after the third hard-fork, <b>the first smart contract</b> was deployed in block <a href='?type=block&height=1280003' title='Block details'>1280003</a>. The contract is a simple <a href='?type=contract&id=3fdd4171972875e0ac8f0131b3da047e8323cc9c2c8d53327be427c455d2a716' title='Smart contract call history'>faucet</a> where people can deposit Beam coins so that any wallet can then get a small amount of it. Due to Beam's low transaction fees, this small amount is already enough for several transactions. Such a faucet is intended to help newcomers discovering the wallet for the first time, even if they don't have any Beam in it yet.<br>Since then, several other smart contracts have been developed, and the list of <a href='?type=contracts' title='List of all deployed smart contracts'>all deployed smart contracts</a> can be seen in the explorer, with the details of the call history for each of them, including the calls to each other, in interesting and powerful sequences (like <a href='?type=contract&id=b8944fd3f6a62697a89b2a55acd1cb2e3893dadece99569706efa1da847dd440' title='Smart contract call history'>Nephrite</a>, the confidential stable coin, interacting with both the <a href='?type=contract&id=4f160f01dcc6751e61d793279b803328d5332125fe8492e93ee8f3bfe9abe13b' title='Smart contract call history'>Oracle</a> and the <a href='?type=contract&id=0066b12078623df132b691001b25d7eb94b207b42c018020c9e58152e21ecd25' title='Smart contract call history'>DAO Vault</a>).",
+      description: "A few minutes after the third hard-fork, <b>the first smart contract</b> was deployed in block <a href='?network=mainnet&type=block&height=1280003' title='Block details'>1280003</a>. The contract is a simple <a href='?network=mainnet&type=contract&id=3fdd4171972875e0ac8f0131b3da047e8323cc9c2c8d53327be427c455d2a716' title='Smart contract call history'>faucet</a> where people can deposit Beam coins so that any wallet can then get a small amount of it. Due to Beam's low transaction fees, this small amount is already enough for several transactions. Such a faucet is intended to help newcomers discovering the wallet for the first time, even if they don't have any Beam in it yet.<br>Since then, several other smart contracts have been developed, and the list of <a href='?network=mainnet&type=contracts' title='List of all deployed smart contracts'>all deployed smart contracts</a> can be seen in the explorer, with the details of the call history for each of them, including the calls to each other, in interesting and powerful sequences (like <a href='?network=mainnet&type=contract&id=b8944fd3f6a62697a89b2a55acd1cb2e3893dadece99569706efa1da847dd440' title='Smart contract call history'>Nephrite</a>, the confidential stable coin, interacting with both the <a href='?network=mainnet&type=contract&id=4f160f01dcc6751e61d793279b803328d5332125fe8492e93ee8f3bfe9abe13b' title='Smart contract call history'>Oracle</a> and the <a href='?network=mainnet&type=contract&id=0066b12078623df132b691001b25d7eb94b207b42c018020c9e58152e21ecd25' title='Smart contract call history'>DAO Vault</a>).",
       links: [['Examples of smart contracts', 'https://github.com/BeamMW/beam/tree/master/bvm/Shaders']]
     },
     {
       block_list: [1464852],
       title: 'BeamX creation',
-      description: "The <b>BeamX</b> confidential asset (<a href='?type=asset&id=7' title='See history of Confidential Asset id:7'>with id:7</a>) is <b>the governance token of the 'BeamX DAO'</b> towards which the <b>Beam Foundation</b> is now transitioning. Its 100,000,000 units were minted all at once by the <a href='?type=contract&id=3f3d32e38cb27ac7b5b67343f81cf2f8bc53217eb995cc6c5d78ddc5e7b0642b' title='Smart contract call history'>DAO Core</a> smart contract, which would later distribute these units over a period of 4 years according to a predefined schedule. Part of the BeamX supply is reserved for liquidity incentives towards Beam's DeFi ecosystem (staking campaigns, liquidity provider rewards, etc.).",
+      description: "The <b>BeamX</b> confidential asset (<a href='?network=mainnet&type=asset&id=7' title='See history of Confidential Asset id:7'>with id:7</a>) is <b>the governance token of the 'BeamX DAO'</b> towards which the <b>Beam Foundation</b> is now transitioning. Its 100,000,000 units were minted all at once by the <a href='?network=mainnet&type=contract&id=3f3d32e38cb27ac7b5b67343f81cf2f8bc53217eb995cc6c5d78ddc5e7b0642b' title='Smart contract call history'>DAO Core</a> smart contract, which would later distribute these units over a period of 4 years according to a predefined schedule. Part of the BeamX supply is reserved for liquidity incentives towards Beam's DeFi ecosystem (staking campaigns, liquidity provider rewards, etc.).",
       links: [
         ['The BeamX DAO', 'https://www.beamxdao.org'],
         ['The BeamX token', 'https://medium.com/beam-mw/introducing-beamx-privacy-by-default-maximum-confidentiality-defi-ecosystem-629670b905ba']
@@ -2642,7 +2661,7 @@
     {
       block_list: [1466501],
       title: 'Start of the first BeamX staking campaign',
-      description: "A first 3-month (131,400 blocks) staking campaign was launched to let users <b>earn BeamX rewards by locking their Beam coins</b>. 1,000,000 BEAMX tokens (1% of the total supply) were distributed this way, and people started staking Beam right after launch, on block <a href='?type=contract&id=3f3d32e38cb27ac7b5b67343f81cf2f8bc53217eb995cc6c5d78ddc5e7b0642b&hMax=1466501&hMin=1464852&nMaxTxs=2000' title='List of deposits into the staking smart contract at block 1466501'>1466501</a>. Although the campaign ended a long time ago, we can see in the 'Locked Funds' section of the contract details that the <a href='?type=contract&id=3f3d32e38cb27ac7b5b67343f81cf2f8bc53217eb995cc6c5d78ddc5e7b0642b&' title='Smart contract call history'>DAO Core</a> contract still holds many Beams that users have not claimed back yet!... Are they yours? ;-)",
+      description: "A first 3-month (131,400 blocks) staking campaign was launched to let users <b>earn BeamX rewards by locking their Beam coins</b>. 1,000,000 BEAMX tokens (1% of the total supply) were distributed this way, and people started staking Beam right after launch, on block <a href='?network=mainnet&type=contract&id=3f3d32e38cb27ac7b5b67343f81cf2f8bc53217eb995cc6c5d78ddc5e7b0642b&hMax=1466501&hMin=1464852&nMaxTxs=2000' title='List of deposits into the staking smart contract at block 1466501'>1466501</a>. Although the campaign ended a long time ago, we can see in the 'Locked Funds' section of the contract details that the <a href='?network=mainnet&type=contract&id=3f3d32e38cb27ac7b5b67343f81cf2f8bc53217eb995cc6c5d78ddc5e7b0642b&' title='Smart contract call history'>DAO Core</a> contract still holds many Beams that users have not claimed back yet!... Are they yours? ;-)",
       links: [
         ['First BeamX reward campaign', 'https://medium.com/@beam_privacy/heres-everything-you-need-to-know-to-prepare-for-beam-staking-108eef344f7d'],
         ['Details on the campaign', 'https://medium.com/beam-mw/beamers-hodlers-beam-staking-is-coming-513bd196af57']
@@ -2661,7 +2680,7 @@
     {
       block_list: [1920000],
       title: 'Fifth Hard-Fork (and wallet v7.1)',
-      description: "As discussed on the Beam Forum, this hard-fork reduced the issuance cost of Confidential Assets from 3000 to 10 BEAM only. The result can be seen, starting with CA id:8, in <a href='?type=assets&height=1981005' title='List of Confidential Assets'>the CAs being created</a> (or re-created, for the older ones) after the fork</a>. The hard-fork also added smart contracts enhancements allowing them to verify fork heights (to support fork-dependent features). On the wallet side, DApp support for the <a href='?type=contract&id=af4550f1f8a6051ffeffea06e0cb978f8076fdfc2101d2273d4e62c86540bc5e' title='Smart contract call history'>BANS</a> (Beam Anonymous Name System) was improved.",
+      description: "As discussed on the Beam Forum, this hard-fork reduced the issuance cost of Confidential Assets from 3000 to 10 BEAM only. The result can be seen, starting with CA id:8, in <a href='?network=mainnet&type=assets&height=1981005' title='List of Confidential Assets'>the CAs being created</a> (or re-created, for the older ones) after the fork</a>. The hard-fork also added smart contracts enhancements allowing them to verify fork heights (to support fork-dependent features). On the wallet side, DApp support for the <a href='?network=mainnet&type=contract&id=af4550f1f8a6051ffeffea06e0cb978f8076fdfc2101d2273d4e62c86540bc5e' title='Smart contract call history'>BANS</a> (Beam Anonymous Name System) was improved.",
       links: [
         ['Announcement', 'https://medium.com/beam-mw/beam-hard-fork-announcement-3e999dfba178'],
         ['Forum post for BIP-1', 'https://forum.beam.mw/t/bip-1-reduce-ca-minting-cost/116']
@@ -2670,13 +2689,13 @@
     {
       block_list: [2272779],
       title: 'Blockchain incident',
-      description: "On May 2023, the Beam <b>blockchain stopped producing blocks</b> for <a href='?type=hdrs&hMax=2272781&nMax=4&cols=THkioyzp' title='Blockchain stop for 103 minutes'>103 minutes</a>. After watching carefully the blockchain activity, the core team managed to identify and correct the problem (which was due to an incorrect sorting of the kernels). All pending transactions were recorded on block <a href='?type=block&height=2272781' title='Blockchain stop for 103 minutes'>2272781</a>. No funds were lost.",
+      description: "On May 2023, the Beam <b>blockchain stopped producing blocks</b> for <a href='?network=mainnet&type=hdrs&hMax=2272781&nMax=4&cols=THkioyzp' title='Blockchain stop for 103 minutes'>103 minutes</a>. After watching carefully the blockchain activity, the core team managed to identify and correct the problem (which was due to an incorrect sorting of the kernels). All pending transactions were recorded on block <a href='?network=mainnet&type=block&height=2272781' title='Blockchain stop for 103 minutes'>2272781</a>. No funds were lost.",
       links: [['Incident analysis', 'https://medium.com/beam-mw/beam-blockchain-incident-analysis-hotfix-for-minor-stoppage-cb96009b8097']]
     },
     {
       block_list: [2628000, 2628001],
       title: 'Second Halving & End of the 5-year treasury allocation',
-      description: "The second halving came shortly after the <b>5-year anniversary of the Beam blockchain</b>, in January 2023. It reduced the block rewards from 50 BEAM (block <a href='?type=block&height=2628000'>2628000</a>) to 25 BEAM (block <a href='?type=block&height=2628001'>2628001</a>).<br>This halving also saw the <a href='?type=block&height=0' title='Treasury'>end of the 5-year treasury allocation</a>: from then on, 100% of the block rewards go to the miners. However, even without treasury allocation, the project is still funded as the <a href='?type=contract&id=0066b12078623df132b691001b25d7eb94b207b42c018020c9e58152e21ecd25' title='Smart contract call history'>DAO Vault</a> receives a share of fees from several DApps of the <b>BeamX ecosystem</b> (DEX, Nephrite, BANS, etc.).",
+      description: "The second halving came shortly after the <b>5-year anniversary of the Beam blockchain</b>, in January 2024. It reduced the block rewards from 50 BEAM (block <a href='?network=mainnet&type=block&height=2628000'>2628000</a>) to 25 BEAM (block <a href='?network=mainnet&type=block&height=2628001'>2628001</a>).<br>This halving also saw the <a href='?network=mainnet&type=block&height=0' title='Treasury'>end of the 5-year treasury allocation</a>: from then on, 100% of the block rewards go to the miners. However, even without treasury allocation, the project is still funded as the <a href='?network=mainnet&type=contract&id=0066b12078623df132b691001b25d7eb94b207b42c018020c9e58152e21ecd25' title='Smart contract call history'>DAO Vault</a> receives a share of fees from several DApps of the <b>BeamX ecosystem</b> (DEX, Nephrite, BANS, etc.).",
       links: [['The 5-year recap', 'https://medium.com/beam-mw/celebrating-beams-5th-anniversary-kick-off-2024-with-beam-wallet-7-5-f5f3cb54e30f']]
     },
   ];
@@ -2931,7 +2950,7 @@
 
 <script> // MISCELLANEOUS STUFF
 
-  // Process a Block/Kernel search request
+  // Process a block/kernel search request
   function submitSearch() {
     // Get search string
     let query = document.getElementById('SearchField').value;
@@ -2941,7 +2960,7 @@
     window.location.href = UrlSelf('block', key + query);
   }
 
-  // Parse Metadata to add classes
+  // Parse metadata to add classes
   function addClassesToMetadata() {
     for (let str of document.querySelectorAll('.metadata')) {
       // Add a class around the asset name (the name field is detected with a regexp)
@@ -2978,8 +2997,10 @@
       myEmptySpan.innerHTML = '(none)';
     }
   }
+</script>
 
-  // ADD EXPAND OPTIONS TO ALL TEXT OF TYPE HASH OR METADATA (CSS WILL DISPLAYED THEM TRUNCATED BY DEFAULT)
+<script> // ADD EXPAND OPTIONS TO ALL HASHES OR METADATA (CSS DISPLAYS THEM TRUNCATED BY DEFAULT)
+
   function addExpandOptions() {
     // Text of type Hash (truncated/expanded)
     for (let myHash of document.querySelectorAll('.cid, .kernelId, .blob, .commitment')) {
@@ -3140,8 +3161,10 @@
     icon.setAttribute('href', 'javascript:expandEverything();');
     icon.setAttribute('title', 'Expand everything');
   }
+</script>
 
-  // SELECTION OPTIONS FOR THE TABLE OF CONTRACT CALLS
+<script> // SELECTION OPTIONS FOR THE TABLE OF CONTRACT CALLS
+
   function DisplayContractOptions() {
     // Display table options
     let text = MakeCollapsibleBegin('Options', 'tableOptions', 'close');
@@ -3197,8 +3220,10 @@
     // Update the query part of the URL and reload page
     window.location.search = args.toString(); // toString() returns the "foo=1&bar=2&baz=3" part (without "?")
   }
+</script>
 
-  // SELECTION OPTIONS FOR THE TABLE OF AN ASSET
+<script> // SELECTION OPTIONS FOR THE TABLE OF AN ASSET
+
   function DisplayAssetOptions() {
     // Display table options
     let text = MakeCollapsibleBegin('Options', 'tableOptions', 'close');
@@ -3254,8 +3279,10 @@
     // Update the query part of the URL and reload page
     window.location.search = args.toString(); // toString() returns the "foo=1&bar=2&baz=3" part (without "?")
   }
+</script>
 
-  // SELECTION OPTIONS FOR THE TABLE OF ALL ASSETS
+<script> // SELECTION OPTIONS FOR THE TABLE OF ALL ASSETS
+
   function DisplayAssetsOptions() {
     // Display table options
     let text = MakeCollapsibleBegin('Options', 'tableOptions', 'close');
@@ -3285,8 +3312,10 @@
     // Update the query part of the URL and reload page
     window.location.search = args.toString(); // toString() returns the "foo=1&bar=2&baz=3" part (without "?")
   }
+</script>
 
-  // SELECTION OPTIONS FOR THE TABLE OF BLOCK HEADERS
+<script> // SELECTION OPTIONS FOR THE TABLE OF BLOCK HEADERS
+
   function DisplayHdrsOptions() {
     // Display table options
     let text = MakeCollapsibleBegin('Options', 'tableOptions', 'close');
@@ -3632,6 +3661,9 @@
       item.innerHTML = nbr.toString().padStart(2,'0') + ". ";
     }
   }
+</script>
+
+<script> // ADD SEARCHING AND FILTERING OPTIONS TO TABLES
 
   // ALLOW ADDING FILTERS TO FIRST ROW OF ALL LONG TABLES
   function addFilterOption() {
@@ -3873,11 +3905,14 @@
       rows[ii].style.visibility = status;
     }
   }
+</script>
+
+<script> // MORE MISCELLANEOUS STUFF
 
   // SCROLL DOWN TO BOTTOM OR BACK TO TOP
   window.onscroll = function () { scrollFunction() }
-  // When the user scrolls away 40px from top or bottom of the page, show the up or down buttons
-  function scrollFunction() {
+
+  function scrollFunction() { // When the user scrolls away 40px from top or bottom of the page, show the up or down buttons
     let myTopButton = document.getElementById('TopButton');
     if (document.body.scrollTop > 40 || document.documentElement.scrollTop > 40) {
       myTopButton.style.display = 'block';
@@ -3891,13 +3926,13 @@
       myBottomButton.style.display = 'none';
     }
   }
-  // Scroll to the top of the document
-  function topFunction() {
+
+  function topFunction() { // Scroll to the top of the document
     document.body.scrollTop = 0; // For Safari
     document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
   }
-  // Scroll to the bottom of the document
-  function bottomFunction() {
+
+  function bottomFunction() { // Scroll to the bottom of the document
     document.body.scrollTop = Math.abs(document.body.scrollHeight - document.body.clientHeight); // For Safari
     document.documentElement.scrollTop = Math.abs(document.documentElement.scrollHeight - document.documentElement.clientHeight); // For Chrome, Firefox, IE and Opera
   }

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -6,7 +6,7 @@
   <!-- WELCOME TO BEAM SMART EXPLORER!
   - This is an interactive web display of the data queried to a Beam explorer node.
   - The IP address of the explorer node can be changed in var 'urlPrefix'.
-  - Current version of the file: v0.7.6
+  - Current version of the file: v0.8
 
   General rules for developement:
   - Let's keep everything in one single standalone file!
@@ -46,10 +46,20 @@
   let mode = localStorage.getItem('mode');
   if (mode) { document.querySelector(':root').classList.add(mode) }
 
-  // Address of the remote explorer node
-  //const urlPrefix = "http://localhost:8888/";
-  //const urlPrefix = 'http://116.203.118.51:8100/';
-  const urlPrefix = 'https://explorer-api.beamprivacy.community/';
+  // List of authorized explorer nodes (URLs must end with "/").
+  // The first one for each network will be the default one.
+  const explorerNodes = {
+    "mainnet": [
+      "https://explorer.0xmx.me/api/",
+      "https://explorer-api.beamprivacy.community/",
+      "https://BeamSmart.net:8000/",
+      //"http://localhost:8888/",
+    ],
+    "dappnet2": [
+      "https://explorer.0xmx.me/api/dappnet2/",
+    ],
+  };
+
 </script>
 
 <!-- ************ SECTION 2 - CSS STYLES ************ -->
@@ -74,6 +84,7 @@
     --color_background_gradient_top: #035b8f;
     --color_background_gradient_main: #042548;
     --color_text: black;
+    --color_sub_text: #ddd;
     --color_h1: #ddd;
     --color_h2: #ddd;
     --color_h2_sub: #ddd;
@@ -81,6 +92,7 @@
     --color_h3_sub: #17204e;
     --color_link: #0066CC;
     --color_link_visited: #3e1a8b;
+    --color_node_url: #00e2c2;
     --color_blockheight_title_link: #65a4e3;
     --color_blockheight_title_link_visited: #a17eec;
     --color_metadata: #505050;
@@ -115,6 +127,7 @@
     --color_popup_border: #ddd;
     --color_popup_background: #042548;
     --color_popup_text : #ddd;
+    --color_popup_url : #00e2c2;
     --color_popup_input_placeholder: #aaa;
     --color_popup_input_text: #eee;
     --color_popup_input_text_invalid: #ff8686;
@@ -144,6 +157,13 @@
     --color_table_row_even: #c9c9c9;
     --color_table_row_hover: #c2c2cf;
     --color_logo_shadow: rgba(255, 255, 255, 0.3);
+    --color_network_select_background: transparent;
+    --color_network_select_background_active: var(--color_banner_search_background);
+    --color_network_select_border: var(--color_banner_search_button_border);
+    --color_network_select_shadow: var(--color_network_select_border);
+    --color_network_select_text: #eee;
+    --color_network_select_hover: #fff;
+    --color_network_select_shadow: rgba(255, 255, 255, 0.3);
     --color_banner_background: rgba(30, 76, 113, 0.4);
     --color_banner_title: #0bccf7;
     --color_banner_version: #00f6d2;
@@ -169,7 +189,7 @@
     --color_footer_text: #0bccf7;
     --color_footer_link: #0bccf7;
     --color_about_text: #ddd;
-    --color_about_link: #5eafff;
+    --color_about_link: #ddd;
     --color_historical_title: #17204e;
     --color_historical_notes: #656565;
     --color_sorting_indicator: #888;
@@ -188,6 +208,7 @@
     --color_background_gradient_top: #d0daff;
     --color_background_gradient_main: #d0daff;
     --color_text: black;
+    --color_sub_text: black;
     --color_h1: black;
     --color_h2: black;
     --color_h2_sub: black;
@@ -195,6 +216,7 @@
     --color_h3_sub: #17204e;
     --color_link: #0066CC;
     --color_link_visited: #3e1a8b;
+    --color_node_url: #2d3799;
     --color_blockheight_title_link: #0066CC;
     --color_blockheight_title_link_visited: #3e1a8b;
     --color_metadata: #505050;
@@ -229,6 +251,7 @@
     --color_popup_border: #17204e;
     --color_popup_background: #d0daff;
     --color_popup_text : black;
+    --color_popup_url : #2d3799;
     --color_popup_input_placeholder: #606060;
     --color_popup_input_text: #525252;
     --color_popup_input_text_invalid: #805353;
@@ -258,6 +281,13 @@
     --color_table_row_even: #eee;
     --color_table_row_hover: #e0e0f0;
     --color_logo_shadow: rgba(0, 0, 0, 0.5);
+    --color_network_select_background: transparent;
+    --color_network_select_background_active: var(--color_banner_search_background);
+    --color_network_select_border: var(--color_banner_search_button_border);
+    --color_network_select_shadow: var(--color_network_select_border);
+    --color_network_select_text: #17204e;
+    --color_network_select_hover: #1f276f;
+    --color_network_select_shadow: rgba(62, 26, 139, 0.2);
     --color_banner_background: #a7acd9;
     --color_banner_title: #17204e;
     --color_banner_version: #525252;
@@ -283,7 +313,7 @@
     --color_footer_text: #17204e;
     --color_footer_link: #17204e;
     --color_about_text: black;
-    --color_about_link: #0066CC;
+    --color_about_link: black;
     --color_historical_title: #17204e;
     --color_historical_notes: grey;
     --color_sorting_indicator: #666;
@@ -649,13 +679,94 @@
     padding: 8px 10px 7px 10px;
     text-align: center;
   }
-  #BeamLogo {
+  #BannerLeft {
     display: table-cell;
     vertical-align: middle;
     text-align: left;
   }
+  #BeamLogo {
+    text-align: center;
+  }
   #BeamLogo:hover svg {
     filter: saturate(1.5) drop-shadow(0 0 5px var(--color_logo_shadow));
+  }
+  #NetworkSelect {
+    border: none;
+    font-size: 1.2rem;
+    text-align: center;
+    color: var(--color_network_select_text);
+    background-color: var(--color_network_select_background);
+    border: 1px solid transparent; /* We define the border here, even transparent, to avoid changes in size when hover */
+    border-radius: 0.5em; /* Slightly round corners */
+    margin: 2px 0 0 0;
+    padding: 2px 2px 4px 2px;
+  }
+  #NetworkSelect:hover, #NetworkSelect:focus {
+    cursor: pointer;
+    border-color: var(--color_network_select_border); /* Display the border */
+    background-color: var(--color_network_select_background_active); /* Change background */
+    filter: drop-shadow(0 0 3px var(--color_network_select_shadow)); /* Add a halo */
+  }
+  #nodeSelectionPopup { /* Dialog popup */
+    border: solid 5px var(--color_popup_border);
+    border-radius: 1rem;
+    box-shadow: 15px 15px 15px -10px #000;
+    background-color: var(--color_popup_background);
+    color: var(--color_popup_text);
+  }
+  #nodeSelectionPopup::backdrop { /* A fun effect, just for backdrops! */
+    background: rgba(0,0,0,30%);
+    backdrop-filter: blur(1px);
+  }
+  #nodeSelectionForm {} /* Form */
+  .nodeSelectionTitle { /* Popup title */
+    font-size: 1.5rem;
+    color: var(--color_popup_text);
+    padding: 0px 2px 0px 2px;
+    text-align: center;
+    font-weight: bold;
+  }
+  .nodeSelectionText { /* Popup text */
+    font-size: 1.3rem;
+    color: var(--color_popup_text);
+    padding: 15px 0 5px 0;
+    text-align: left;
+    font-weight: bold;
+  }
+  #NodeSelectionList { /* List of explorer nodes URLs */
+    padding: 0px 5px 10px 5px;
+  }
+  .nodeSelectionRadio { /* Radio button */
+    vertical-align: bottom;
+    margin: 5px 10px 0px 0px;
+  }
+  .nodeSelectionURL {
+    font-family: "Lucida Console", ui-monospace, monospace;
+    font-size: 1.2rem;
+    color: var(--color_popup_url);
+    text-align: left;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+  .nodeSelectionButtons { /* List of explore nodes URLs */
+    padding: 5px 5px 5px 5px;
+    text-align: center;
+  }
+  .popupButton { /* Buttons */
+    cursor: pointer;
+    margin: 2px 2px 2px 2px;
+    padding: 5px 10px 5px 10px;
+    font-weight: bold;
+    color: var(--color_popup_button_text);
+    background-color: var(--color_popup_button_background);
+    border: solid 1px var(--color_popup_button_border);
+    border-radius: 0.35em; /* Slightly round corners */
+    vertical-align: middle;
+  }
+  .popupButton:hover, .popupButton:focus {
+    outline: none; /* Avoid the browser default focus outline */
+    background-color: var(--color_popup_button_background_hover);
+    filter: drop-shadow(0 0 1px var(--color_popup_button_border));
   }
   #BannerCenter{
     display: table-cell;
@@ -866,13 +977,23 @@
     0%,40%,100% { transform: translateY(0) }
     20% { transform: translateY(-1rem) }
   }
-  #Querying {
-    font-family: "Lucida Console", ui-monospace, monospace;
+  .querying {
     font-weight: normal;
-    font-size: 1rem;
-    white-space: nowrap; /* Don't wrap text */
-    color: var(--color_h2_sub);
+    font-size: 1.2rem;
+    color: var(--color_sub_text);
     vertical-align: middle;
+  }
+  .querying a {
+    color: var(--color_sub_text);
+  }
+  .queried-network {
+    font-weight: bold;
+  }
+  .queried-node {
+    font-family: "Lucida Console", ui-monospace, monospace;
+    font-size: 1.1rem;
+    color: var(--color_node_url);
+    white-space: nowrap;
   }
 
   /* GENERAL COLLAPSIBLE BLOCKS */
@@ -1097,7 +1218,7 @@
     background-color: var(--color_popup_background);
     color: var(--color_popup_text);
   }
-  ::backdrop { /* A fun effect, just for backdrops! */
+  #pasteColumnsPopup::backdrop { /* A fun effect, just for backdrops! */
     background: rgba(0,0,0,30%);
     backdrop-filter: blur(1px);
   }
@@ -1138,23 +1259,6 @@
     font-style: italic;
     color: var(--color_popup_input_placeholder);
     text-decoration: none;
-  }
-  #pasteColumnsApply, #pasteColumnsCancel { /* Buttons */
-    cursor: pointer;
-    margin: 2px 2px 2px 2px;
-    padding: 5px 10px 5px 10px;
-    font-weight: bold;
-    color: var(--color_popup_button_text);
-    background-color: var(--color_popup_button_background);
-    border: solid 1px var(--color_popup_button_border);
-    border-radius: 0.35em; /* Slightly round corners */
-    vertical-align: middle;
-  }
-  #pasteColumnsApply:hover, #pasteColumnsCancel:hover,
-  #pasteColumnsApply:focus, #pasteColumnsCancel:focus {
-    outline: none; /* Avoid the browser default focus outline */
-    background-color: var(--color_popup_button_background_hover);
-    filter: drop-shadow(0 0 1px var(--color_popup_button_border));
   }
   .pasteColumnsText { /* Popup text */
     font-size: 1.5rem;
@@ -1430,24 +1534,44 @@
 
       <!-- Fixed banner on all pages -->
       <div id="Banner">
-        <span id="BeamLogo">
-          <!-- Clicking on the logo sends back to the main page -->
-          <a href='?' title='Main page'>
-            <!-- A simplified SVG version of the BEAM logo -->
-            <svg height='6em' width='6em' viewBox='42 42 460 460'><defs><linearGradient id='Gradient1' x1='-24.6' y1='683.51' x2='-23.57' y2='683.51' gradientTransform='matrix(98, 0, 0, -47, 2497.75, 32364.11)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#fff' stop-opacity='0'/><stop offset='1' stop-color='#fff'/></linearGradient><linearGradient id='Gradient2' x1='-28.7' y1='703.17' x2='-27.72' y2='703.17' gradientTransform='matrix(-98, 0, 0, 26, -2353.25, -18019.72)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#9d6eff' stop-opacity='0'/><stop offset='1' stop-color='#a18cff'/></linearGradient><linearGradient id='Gradient3' x1='-28.69' y1='682.8' x2='-27.57' y2='682.8' gradientTransform='translate(-2353.25 29603.78) rotate(180) scale(98 43)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#ae60d6' stop-opacity='0'/><stop offset='1' stop-color='#ab38e6'/></linearGradient><linearGradient id='Gradient4' x1='-28.68' y1='685.09' x2='-27.47' y2='685.09' gradientTransform='translate(-2353.25 41328.94) rotate(180) scale(98 60)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#fd76fd' stop-opacity='0'/><stop offset='1' stop-color='#ff51ff'/></linearGradient></defs><circle id='circle' fill='#0b1624' cx='272' cy='272' r='230'/><g id='logo'><path id='Triangle-left' fill='#24c1ff' d='M272.25,327.21H194.72l77.5-135V110.45L120.31,370.64H272.25Z'/><path id='Triangle-right' fill='#0b76ff' d='M272.25,327.21h77.53l-77.5-135V110.45L424.19,370.64H272.25Z'/><polygon id='Triangle-small-left' fill='#39fff2' points='272.25 226.3 272.25 313.57 224.77 313.67 272.25 226.3'/><polygon id='Triangle-small-right' fill='#00e2c2' points='272.25 226.3 272.25 313.57 319.73 313.67 272.25 226.3'/><polygon id='Ray1-left' fill='url(#Gradient1)' points='86.13 191.81 272.25 277.83 272.25 286.83 86.13 246.1 86.13 191.81'/><polygon id='Ray2-right-low' fill='url(#Gradient2)' points='458.75 274.33 272.25 286.83 272.25 283.83 458.75 238.5 458.75 274.33'/><polygon id='Ray3-right-mid' fill='url(#Gradient3)' points='458.75 202.67 272.25 280.83 272.25 283.83 458.75 238.5 458.75 202.67'/><polygon id='Ray4-right-top' fill='url(#Gradient4)' points='458.75 166.83 272.25 277.83 272.25 280.83 458.75 202.67 458.75 166.83'/></g></svg>
-          </a>
-        </span>
+        <div id="BannerLeft">
+          <div id="BeamLogo">
+            <!-- Clicking on the logo sends back to the main page -->
+            <a href='?network=$network' title='Main page'>
+              <!-- A simplified SVG version of the BEAM logo -->
+              <svg height='6em' width='6em' viewBox='42 42 460 460'><defs><linearGradient id='Gradient1' x1='-24.6' y1='683.51' x2='-23.57' y2='683.51' gradientTransform='matrix(98, 0, 0, -47, 2497.75, 32364.11)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#fff' stop-opacity='0'/><stop offset='1' stop-color='#fff'/></linearGradient><linearGradient id='Gradient2' x1='-28.7' y1='703.17' x2='-27.72' y2='703.17' gradientTransform='matrix(-98, 0, 0, 26, -2353.25, -18019.72)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#9d6eff' stop-opacity='0'/><stop offset='1' stop-color='#a18cff'/></linearGradient><linearGradient id='Gradient3' x1='-28.69' y1='682.8' x2='-27.57' y2='682.8' gradientTransform='translate(-2353.25 29603.78) rotate(180) scale(98 43)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#ae60d6' stop-opacity='0'/><stop offset='1' stop-color='#ab38e6'/></linearGradient><linearGradient id='Gradient4' x1='-28.68' y1='685.09' x2='-27.47' y2='685.09' gradientTransform='translate(-2353.25 41328.94) rotate(180) scale(98 60)' gradientUnits='userSpaceOnUse'><stop offset='0' stop-color='#fd76fd' stop-opacity='0'/><stop offset='1' stop-color='#ff51ff'/></linearGradient></defs><circle id='circle' fill='#0b1624' cx='272' cy='272' r='230'/><g id='logo'><path id='Triangle-left' fill='#24c1ff' d='M272.25,327.21H194.72l77.5-135V110.45L120.31,370.64H272.25Z'/><path id='Triangle-right' fill='#0b76ff' d='M272.25,327.21h77.53l-77.5-135V110.45L424.19,370.64H272.25Z'/><polygon id='Triangle-small-left' fill='#39fff2' points='272.25 226.3 272.25 313.57 224.77 313.67 272.25 226.3'/><polygon id='Triangle-small-right' fill='#00e2c2' points='272.25 226.3 272.25 313.57 319.73 313.67 272.25 226.3'/><polygon id='Ray1-left' fill='url(#Gradient1)' points='86.13 191.81 272.25 277.83 272.25 286.83 86.13 246.1 86.13 191.81'/><polygon id='Ray2-right-low' fill='url(#Gradient2)' points='458.75 274.33 272.25 286.83 272.25 283.83 458.75 238.5 458.75 274.33'/><polygon id='Ray3-right-mid' fill='url(#Gradient3)' points='458.75 202.67 272.25 280.83 272.25 283.83 458.75 238.5 458.75 202.67'/><polygon id='Ray4-right-top' fill='url(#Gradient4)' points='458.75 166.83 272.25 277.83 272.25 280.83 458.75 202.67 458.75 166.83'/></g></svg>
+            </a>
+          </div>
+          <div id="Network">
+            <!-- Network selection dropdown (the options will be added by JS) -->
+            <select id="NetworkSelect" title="Change network" name="network"></select>
+            <!-- Popup for selecting the network (will be activated by a link in the About section) -->
+            <!-- Remark: We use 'dialog' because 'popover' does not work on Chrome 83. -->
+            <dialog id="nodeSelectionPopup">
+              <form id="nodeSelectionForm" name="nodeSelectionForm" method="dialog" onsubmit="applyNodeSelection();">
+                <div class="nodeSelectionTitle">- Explorer nodes -</div>
+                <!-- Display a list of explorer nodes URLs (the list will be added by JS) -->
+                <div id="NodeSelectionList"></div>
+                <div class="nodeSelectionButtons">
+                  <button type="submit" class="popupButton" id="nodeSelectionApply" title="Save prefered explorer nodes">Apply</button>
+                  <button type="button" class="popupButton" id="nodeSelectionDefault" title="Select default explorer nodes" onclick="defaultNodeSelection();">Default</button>
+                  <button type="button" class="popupButton" id="nodeSelectionCancel" title="Cancel" onclick="closeNodeSelection();">Cancel</button>
+                </div>
+              </form>
+            </dialog>
+          </div>
+        </div>
         <div id="BannerCenter">
           <h1 id="BeamTitle">Beam Smart Explorer <span id='Version'>v0.7.6</span></h1>
           <div id="Menu">
             <!-- Main explorer menu -->
-            <span class="menuItem"><a href="?type=hdrs" title="List of recent Block Headers">Block Headers</a></span>
+            <span class="menuItem"><a href="?network=$network&type=hdrs" title="List of recent Block Headers">Block Headers</a></span>
             <span class="menuSeparator"> | </span>
-            <span class="menuItem"><a href="?type=assets" title="List of current Confidential Assets">Confidential Assets</a></span>
+            <span class="menuItem"><a href="?network=$network&type=assets" title="List of current Confidential Assets">Confidential Assets</a></span>
             <span class="menuSeparator"> | </span>
-            <span class="menuItem"><a href="?type=contracts" title="List of currently deployed Smart Contracts">Smart Contracts</a></span>
+            <span class="menuItem"><a href="?network=$network&type=contracts" title="List of currently deployed Smart Contracts">Smart Contracts</a></span>
             <span class="menuSeparator"> | </span>
-            <span class="menuItem"><a href="?type=historical" title="List of special historical blocks">Historical blocks</a></span>
+            <span class="menuItem"><a href="?network=$network&type=historical" title="List of special historical blocks">Historical blocks</a></span>
           </div>
           <div id="SearchArea">
             <!-- Search field -->
@@ -1478,7 +1602,8 @@
       <div id="MainContent">
         <!-- Dots are isolated, for CSS animation... -->
         <h2 id="Loading">Loading<span style="--t:1">.</span><span style="--t:2">.</span><span style="--t:3">.</span></h2>
-        <p id="Querying">Querying explorer node at <script>document.write(urlPrefix);</script></p>
+        <p class="querying">Querying explorer node for <span class="queried-network"></span>: <span class="queried-node"></span></p>
+        <p class="querying">&#9656; <a href='javascript:openNodeSelection();' title='Show list of explorer nodes'>List of available nodes.</a></p>
       </div>
 
     </div>
@@ -1499,7 +1624,7 @@
   }
 
   function UrlSelf(type, extra = '') {
-    return window.location.pathname + '?type=' + type + extra;
+    return window.location.pathname + '?network=' + g_network + '&type=' + type + extra;
   }
 
   function MakeCell(text, styles = '') {
@@ -2263,7 +2388,8 @@
             The <b>Smart Contracts</b> history is available too, with details of all their calls (although their users remain confidential).";
     text += "</p>\n";
     text += "<p class='aboutText'>";
-    text += "This app is an interactive web display of the data queried to a Beam explorer node. \
+    text += "This app is an interactive web display of the data queried to a Beam explorer node \
+            (selected from a <a href='javascript:openNodeSelection();' title='Show list of explorer nodes'>predefined list</a>).\
             The whole interface is held in <b>one single HTML file</b>, written in vanilla HTML/JS/CSS and with no external dependencies. \
             You can save the HTML file and simply open it locally in your browser! Source is also available on <a href='https://github.com/BeamMW/beam/tree/master/explorer/htm' target='_blank'>Github</a>.";
     text += "</p>\n";
@@ -2363,11 +2489,12 @@
 <script> // ADDITIONAL GLOBAL VARIABLES
 
   // Array of codes, names and descriptions for the Block Header columns
-  const columnDefaultOrder = "THgGdDfFkKiIoOuUyYzZbBpPcCaA"; // Without "t" (which is redundant with "g")
+  const columnDefaultOrder = "NTHgGdDfFkKiIoOuUyYzZbBpPcCaA"; // Without "t" (which is redundant with "g")
   const columnDefaultDisplay = "THdfkioyzp";
   const columnHeaders = [
     { code: "h", original: "Height", title: "Height", description: "Block height" }, // Remark: The code here is useless as this is always the default first column
     { code: "H", original: "Hash", title: "Hash", description: "Block hash" },
+    { code: "N", original: "Number", title: "Number", description: "Block number (in pBFT chains)" }, // Only available for pBFT chains
     //{ code: "t", original: "d.Time", title: "Time", description: "Block duration (in seconds)" }, // Redundant with "g"
     { code: "T", original: "Timestamp", title: "Timestamp", description: "Block timestamp (UTC)" },
     { code: "g", original: "d.Age", title: "Duration", description: "Block duration (in seconds)" },
@@ -2554,8 +2681,9 @@
     },
   ];
 
-  // URL and explorer node parameters
+  // Get URL parameters
   const URLparams = new URL(document.location).searchParams;
+  let g_network = URLparams.get('network'); // Should be one of those defined in global variable 'explorerNodes'
   let g_type = URLparams.get('type'); // Remark: We add two URL 'types' not used by the explorer node ("historical" and "treasury")
   let g_id = URLparams.get('id'); // Used for type=asset & contract
   let g_height = URLparams.get('height'); // Used for type=block & blocks & assets
@@ -2587,6 +2715,91 @@
   if (!g_cols) { g_cols = columnDefaultDisplay; }
   if (!g_dh) { g_dh = localStorage.getItem('g_dh'); }
   if (!g_dh) { g_dh = 1 }
+
+</script>
+
+<script> // UPDATE DISPLAY WITH AVAILABLE NETWORKS AND EXPLORER NODES
+
+  // Define default explorer nodes to query
+  let g_defaultNodes;
+  try { // Try to read list from local storage (getItem returns 'null' if the variable doesn't exist)
+    g_defaultNodes = JSON.parse(localStorage.getItem('g_defaultNodes'));
+  } catch (error) { // In case of any parsing error, also set the variable to 'null'
+    g_defaultNodes = null;
+  }
+  // If the variable doesn't exist or is not a literal object, then we set it with the default nodes
+  if (g_defaultNodes === null || g_defaultNodes.constructor !== Object) {
+    g_defaultNodes = {};
+    for (let network in explorerNodes) {
+      g_defaultNodes[network] = explorerNodes[network][0]; // First node is used as default one
+    }
+  // If the variable exists, then we thoroughly verify that its content is valid (authorized networks and nodes)
+  } else {
+    // First we remove any network that is not authorized
+    for (let network in g_defaultNodes) {
+      if (explorerNodes[network] === undefined) {
+        delete g_defaultNodes[network]; 
+      }
+    }
+    // If a network is missing, or if the node given for it is unknown, then we set the network with its default node
+    for (let network in explorerNodes) {
+      if (g_defaultNodes[network] === undefined || !explorerNodes[network].includes(g_defaultNodes[network])) {
+        g_defaultNodes[network] = explorerNodes[network][0]; // First node is used as default one
+      }
+    }
+  }
+  // Save in local storage
+  localStorage.setItem('g_defaultNodes',JSON.stringify(g_defaultNodes));
+
+  // Fill the network selection dropdown and the popup network list
+  let nodesList = "";
+  let networkOptions = "";
+  for (let network in explorerNodes) {
+    // Create new option for the dropdown
+    networkOptions += '<option value="' + network + '">' + network + '</option>';
+    // Add nodes to the popup list
+    nodesList += '<div class="nodeSelectionText">' + network + ' :</div>';
+    let nodes = explorerNodes[network];
+    for (let i = 0; i < nodes.length; i++) {
+      let node = nodes[i];
+      let id = network + ' node ' + i;
+      nodesList += '<input type="radio" id="' + id + '" class="nodeSelectionRadio" name="' + network + '" value="' + node + '">';
+      nodesList += '<label for="' + id + '" class="nodeSelectionURL">' + node + '</label><br>';
+      // Remark: All radios start unchecked. Radios of default nodes will be checked at popup opening.
+    }
+  }
+  // Add the elements to HTML
+  document.getElementById('NodeSelectionList').innerHTML = nodesList;
+  document.getElementById('NetworkSelect').innerHTML = networkOptions;
+
+  // Get the node URL to query for the requested network
+  let urlPrefix = g_defaultNodes[g_network];
+  // If the requested network in the URL was not found, then default to 'mainnet'
+  if (urlPrefix === undefined) {
+    g_network = 'mainnet';
+    urlPrefix = g_defaultNodes['mainnet'];
+  }
+
+  // Put the current network in all links
+  const encodedNetwork = encodeURIComponent(g_network);
+  document.querySelectorAll('a[href]').forEach(link => {
+    const href = link.getAttribute('href');
+    if (href.includes('$network')) {
+      link.href = href.replace(/\$network/g, encodedNetwork); // Using regexp because replaceAll is not available in Chrome 83
+    }
+  });
+
+  // Put the current network in ad-hoc text elements
+  document.querySelectorAll('.queried-node').forEach(item => { item.textContent = urlPrefix; });
+  document.querySelectorAll('.queried-network').forEach(item => { item.textContent = g_network; });
+
+  // Set current value in the network dropdown
+  document.getElementById('NetworkSelect').value = g_network;
+  // Add reload event to network selection dropdown
+  document.getElementById('NetworkSelect').addEventListener('change', function() {
+    window.location.search = '?network=' + encodeURIComponent(this.value);
+  });
+
 </script>
 
 <script> // QUERY EXPLORER NODE
@@ -2665,7 +2878,58 @@
 </script>
 
 <!-- ************ SECTION 6 - EXTRA JS FUNCTIONS ************ -->
-<script>
+<script> // MANAGE POPUP FOR EXPLORER NODE SELECTION
+
+  function checkNodeSelection() { // Check radios of default nodes (and uncheck the others)
+    for (let network in explorerNodes) {
+      let nodes = explorerNodes[network];
+      for (let i = 0; i < nodes.length; i++) {
+        let id = network + ' node ' + i;
+        let check = (nodes[i] == g_defaultNodes[network]);
+        document.getElementById(id).checked = check;
+      }
+    }
+  }
+
+  function openNodeSelection() { // Open popup for Explorer Node Selection
+    let popup = document.getElementById('nodeSelectionPopup');
+    // Check radios of default nodes
+    checkNodeSelection();
+    // Display popup
+    popup.showModal();
+    // Close popup if we click outside of it (...I'm not sure I understand how this one works!)
+    popup.addEventListener('click', function (event) { if (event.target === popup) { popup.close(); } });
+  }
+
+  function closeNodeSelection() { // Close popup
+    document.getElementById('nodeSelectionPopup').close();
+  }
+
+  function defaultNodeSelection() { // Reset selection to default nodes
+    // Check radios of default nodes (i.e. the first for each network)
+    for (let network in explorerNodes) {
+      let id = network + ' node ' + 0;
+      document.getElementById(id).checked = true;
+    }
+  }
+
+  function applyNodeSelection() { // Apply popup selection
+    let popup = document.getElementById('nodeSelectionPopup');
+    // Update global variable with selected nodes
+    for (let network in explorerNodes) {
+      let nodes = explorerNodes[network];
+      for (let i = 0; i < nodes.length; i++) {
+        let id = network + ' node ' + i;
+        if (document.getElementById(id).checked) { g_defaultNodes[network] = nodes[i]; };
+      }
+    }
+    // Save in local storage
+    localStorage.setItem('g_defaultNodes',JSON.stringify(g_defaultNodes));
+    // Remark: No need to close the popup (submitting a form with a 'dialog' method automatically closes the dialog)
+  }
+</script>
+
+<script> // MISCELLANEOUS STUFF
 
   // Process a Block/Kernel search request
   function submitSearch() {
@@ -3108,8 +3372,8 @@
     text += "  <form id='pasteColumnsForm' name='pasteColumnsForm' method='dialog' onsubmit='applyPasteColumns();'>\
                   <div class='pasteColumnsText'>Copy/Paste codes for columns:</div>\
                   <input type='text' id='pasteColumnsInput' value='" + columnDefaultDisplay + "' autocomplete='off' size='30' pattern='^(?:([" + columnDefaultOrder + "])(?!.*\\1))*$' placeholder='Enter column codes here' title='Valid codes are " + columnDefaultOrder + " (without repetition)' autofocus>\
-                  <button type='submit' id='pasteColumnsApply' title='Apply column codes'>Ok</button>\
-                  <button type='button' id='pasteColumnsCancel' title='Cancel' onclick='closePasteColumns();'>Cancel</button>\
+                  <button type='submit' class='popupButton' id='pasteColumnsApply' title='Apply column codes'>Ok</button>\
+                  <button type='button' class='popupButton' id='pasteColumnsCancel' title='Cancel' onclick='closePasteColumns();'>Cancel</button>\
                </form>";
     // Display a list of all column codes
     text += "<div class='pasteColumnsList'>";

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -1582,7 +1582,7 @@
           </div>
         </div>
         <div id="BannerCenter">
-          <h1 id="BeamTitle">Beam Smart Explorer <span id='Version'>v0.7.6</span></h1>
+          <h1 id="BeamTitle">Beam Smart Explorer <span id='Version'>v0.8</span></h1>
           <div id="Menu">
             <!-- Main explorer menu -->
             <span class="menuItem"><a href="?network=$network&type=hdrs" title="List of recent Block Headers">Block Headers</a></span>

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -1933,6 +1933,11 @@
       return;
     }
 
+    // the returned height may be adjusted
+    let jH = jData['h'];
+    if (jH != null)
+        g_height = jH;
+
     // Parse "info" section
     let j = jData['info'];
 
@@ -1946,13 +1951,13 @@
       text += '&nbsp;';
       text += 'Block ' + AddClass(g_height, 'blockHeight');
       text += '&nbsp;';
-      text += AddClass(MakeRef(UrlBlock(g_height - 1), "<svg width='1em' height='1em'><use href='#left_icon'/></svg>"), 'previousBlock', "title='Previous block'");
+      text += AddClass(MakeRef(UrlBlock(g_height - 1) + '&adj=-1', "<svg width='1em' height='1em'><use href='#left_icon'/></svg>"), 'previousBlock', "title='Previous block'");
     } else {
       text += 'Treasury';
       text += '&nbsp;';
       text += AddClass("<svg width='1em' height='1em'><use href='#left_icon'/></svg>", 'previousBlock off', "title=''");
     }
-    text += AddClass(MakeRef(UrlBlock(g_height - 1 + 2), "<svg width='1em' height='1em'><use href='#right_icon'/></svg>"), 'nextBlock', "title='Next block'");
+    text += AddClass(MakeRef(UrlBlock(g_height - 1 + 2) + '&adj=1', "<svg width='1em' height='1em'><use href='#right_icon'/></svg>"), 'nextBlock', "title='Next block'");
     text += '</h2>';
 
     if (j) {
@@ -2610,6 +2615,9 @@
     } else if (g_type == 'block') { // Arguments for 'block': height OR kernel (we let the explorer node handle the case where both are requested)
       if (g_kernel) { urlSuffix += '&kernel=' + g_kernel; }
       if (g_height) { urlSuffix += '&height=' + g_height; }
+      adj = URLparams.get('adj'); // Used to adjust the block height, if there's no exact match
+      if (adj != null)
+        urlSuffix += '&adj=' + adj;
       xmlhttp.onload = DisplayBlock;
 
     } else if (g_type == 'treasury') { // 'treasury' is type 'block' but with height=0


### PR DESCRIPTION
Updates for v0.8:
- Manage a new "adj" node parameter, for missing blocks heights in pBFT chains.
- Allow switching between networks (mainnet, dappnet, etc.).
- Add a network option in URL parameters.
- Add a popup to select explorer nodes to query.
- Add "network" parameter in all links of the "Historical Blocks" page.
- add some extra <script> tags to better organize code.
- Add some more info in the "About" section.
- Some small adjustment to code and comments.