### PR TITLE
#1990: display current block instead of treasury when calling block w…

### DIFF
--- a/explorer/adapter.cpp
+++ b/explorer/adapter.cpp
@@ -2859,6 +2859,13 @@ private:
                 // ignore other cases
             }
         }
+        else
+        {
+            // No height specified — return the current (latest) block
+            sid = _nodeBackend.m_Cursor.get_Sid();
+            s = _nodeBackend.m_Cursor.m_Full;
+            h = _nodeBackend.m_Cursor.m_hh.m_Height;
+        }
 
         if (h)
             return extract_block_from_row(sid, s, h);


### PR DESCRIPTION
display current block instead of treasury when calling block with no arguments

The get_treasury fallback is kept for safety (e.g., if the node has no blocks yet and h is still 0 after the else branch), but in practice it will never be reached under normal operation.