### PR TITLE
Explorer node: add asset_swaps and asset_swaps_totals endpoints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ else()
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable") # osx 13.3 clang 14 core/merkle.cpp
         endif()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-enum-constexpr-conversion -Wno-error=enum-constexpr-conversion -Wno-vla-cxx-extension")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-literal-operator") # newer clang vs old 3rdparty/nlohmann json.hpp operator "" _json
     endif()
 endif()
 

--- a/explorer/CMakeLists.txt
+++ b/explorer/CMakeLists.txt
@@ -11,7 +11,7 @@ set(EXPLORER_SRC
 
 add_library(explorer STATIC ${EXPLORER_SRC})
 
-target_link_libraries(explorer node http swap_offers_board)
+target_link_libraries(explorer node http swap_offers_board dex_board)
 
 add_executable(${TARGET_NAME} explorer_node.cpp)
 if(LINUX)

--- a/explorer/adapter.cpp
+++ b/explorer/adapter.cpp
@@ -36,6 +36,10 @@
 #include "wallet/client/extensions/offers_board/swap_offers_board.h"
 #endif  // BEAM_ATOMIC_SWAP_SUPPORT
 
+#ifdef BEAM_ASSET_SWAP_SUPPORT
+#include "wallet/client/extensions/dex_board/dex_board.h"
+#endif  // BEAM_ASSET_SWAP_SUPPORT
+
 namespace beam { namespace explorer {
 
 namespace {
@@ -217,6 +221,10 @@ public:
 
         _broadcastRouter = std::make_shared<BroadcastRouter>(nnet, *wnet, std::make_shared<BroadcastRouter::BbsTsHolder>(_walletDB));
         _exchangeRateProvider = std::make_shared<ExchangeRateProvider>(*_broadcastRouter, _walletDB);
+
+#ifdef BEAM_ASSET_SWAP_SUPPORT
+        _dexBoard = std::make_shared<wallet::DexBoard>(*_broadcastRouter, _dexCtlGateway, *_walletDB);
+#endif  // BEAM_ASSET_SWAP_SUPPORT
 
 #ifdef BEAM_ATOMIC_SWAP_SUPPORT
         _offerBoardProtocolHandler =
@@ -3040,6 +3048,79 @@ private:
     }
 #endif  // BEAM_ATOMIC_SWAP_SUPPORT
 
+#ifdef BEAM_ASSET_SWAP_SUPPORT
+    json get_asset_swaps() override
+    {
+        json result = json::array();
+        if (!_dexBoard)
+            return result;
+
+        for (const auto& order : _dexBoard->getDexOrders())
+        {
+            if (order.isExpired())
+                continue;
+
+            result.push_back(json{
+                {"id", order.getID().to_string()},
+                {"send_asset_id", order.getFirstAssetId()},
+                {"send_currency", order.getFirstAssetSname()},
+                {"send_amount", std::to_string(order.getFirstAmount())},
+                {"receive_asset_id", order.getSecondAssetId()},
+                {"receive_currency", order.getSecondAssetSname()},
+                {"receive_amount", std::to_string(order.getSecondAmount())},
+                {"create_time", format_timestamp(wallet::kTimeStampFormat3x3, order.getCreation() * 1000, false)},
+                {"expire_time", format_timestamp(wallet::kTimeStampFormat3x3, order.getExpiration() * 1000, false)},
+                {"is_mine", order.isMine()},
+            });
+        }
+
+        return result;
+    }
+
+    json get_asset_swaps_totals() override
+    {
+        struct Agg { Amount offered = 0; Amount wanted = 0; std::string sname; };
+        std::map<Asset::ID, Agg> totals;
+        uint64_t count = 0;
+
+        if (_dexBoard)
+        {
+            for (const auto& order : _dexBoard->getDexOrders())
+            {
+                if (order.isExpired())
+                    continue;
+                ++count;
+
+                auto& offeredAsset = totals[order.getFirstAssetId()];
+                offeredAsset.offered += order.getFirstAmount();
+                if (offeredAsset.sname.empty())
+                    offeredAsset.sname = order.getFirstAssetSname();
+
+                auto& wantedAsset = totals[order.getSecondAssetId()];
+                wantedAsset.wanted += order.getSecondAmount();
+                if (wantedAsset.sname.empty())
+                    wantedAsset.sname = order.getSecondAssetSname();
+            }
+        }
+
+        json assets = json::array();
+        for (const auto& pair : totals)
+        {
+            assets.push_back(json{
+                {"asset_id", pair.first},
+                {"currency", pair.second.sname},
+                {"amount_offered", std::to_string(pair.second.offered)},
+                {"amount_wanted", std::to_string(pair.second.wanted)},
+            });
+        }
+
+        return json{
+            {"total_offers_count", count},
+            {"assets", assets},
+        };
+    }
+#endif  // BEAM_ASSET_SWAP_SUPPORT
+
     HttpMsgCreator _packer;
 
     // node db interface
@@ -3060,6 +3141,10 @@ private:
     wallet::Wallet::Ptr _wallet;
     std::shared_ptr<beam::BroadcastRouter> _broadcastRouter;
     std::shared_ptr<ExchangeRateProvider> _exchangeRateProvider;
+#ifdef BEAM_ASSET_SWAP_SUPPORT
+    wallet::IRawCommGateway _dexCtlGateway;
+    wallet::DexBoard::Ptr _dexBoard;
+#endif  // BEAM_ASSET_SWAP_SUPPORT
 #ifdef BEAM_ATOMIC_SWAP_SUPPORT
     std::shared_ptr<wallet::OfferBoardProtocolHandler> _offerBoardProtocolHandler;
     wallet::SwapOffersBoard::Ptr _offersBulletinBoard;

--- a/explorer/adapter.cpp
+++ b/explorer/adapter.cpp
@@ -3064,13 +3064,12 @@ private:
                 {"id", order.getID().to_string()},
                 {"send_asset_id", order.getFirstAssetId()},
                 {"send_currency", order.getFirstAssetSname()},
-                {"send_amount", std::to_string(order.getFirstAmount())},
+                {"send_amount", std::to_string(wallet::PrintableAmount(order.getFirstAmount()))},
                 {"receive_asset_id", order.getSecondAssetId()},
                 {"receive_currency", order.getSecondAssetSname()},
-                {"receive_amount", std::to_string(order.getSecondAmount())},
+                {"receive_amount", std::to_string(wallet::PrintableAmount(order.getSecondAmount()))},
                 {"create_time", format_timestamp(wallet::kTimeStampFormat3x3, order.getCreation() * 1000, false)},
                 {"expire_time", format_timestamp(wallet::kTimeStampFormat3x3, order.getExpiration() * 1000, false)},
-                {"is_mine", order.isMine()},
             });
         }
 
@@ -3109,8 +3108,8 @@ private:
             assets.push_back(json{
                 {"asset_id", pair.first},
                 {"currency", pair.second.sname},
-                {"amount_offered", std::to_string(pair.second.offered)},
-                {"amount_wanted", std::to_string(pair.second.wanted)},
+                {"amount_offered", std::to_string(wallet::PrintableAmount(pair.second.offered))},
+                {"amount_wanted", std::to_string(wallet::PrintableAmount(pair.second.wanted))},
             });
         }
 

--- a/explorer/adapter.cpp
+++ b/explorer/adapter.cpp
@@ -438,10 +438,16 @@ private:
             get_TreasuryTotals(sd.m_Totals);
     }
 
+    static uint64_t get_Timestamp_ms_safe(const Block::SystemState::Full& s)
+    {
+        return (Rules::Consensus::Pbft == Rules::get().m_Consensus)
+            ? s.get_Timestamp_ms()
+            : (uint64_t) s.m_TimeStamp * 1000;
+    }
+
     static double get_Timestamp_s(const Block::SystemState::Full& s)
     {
-        auto ts_ms = s.get_Timestamp_ms();
-        return ((double)ts_ms) / 1000.;
+        return ((double) get_Timestamp_ms_safe(s)) / 1000.;
     }
 
     uint64_t m_tsBlock1_ms = 0;
@@ -454,7 +460,7 @@ private:
             auto row = _nodeBackend.FindActiveAtStrict(Block::Number(1));
             _nodeBackend.get_DB().get_State(row, s);
 
-            m_tsBlock1_ms = s.get_Timestamp_ms();
+            m_tsBlock1_ms = get_Timestamp_ms_safe(s);
         }
 
         return m_tsBlock1_ms;
@@ -2371,11 +2377,11 @@ private:
         void OnName_Time_Abs() { m_json.push_back(MakeTableHdr("Timestamp")); }
         void OnName_Time_Rel() { m_json.push_back(MakeTableHdr("d.Time")); }
         void OnData_Time_Abs() { m_json.push_back(MakeTypeObj("time", get_Timestamp_s(m_pThis->m_Hdr))); }
-        void OnData_Time_Rel() { m_json.push_back(m_This.MakeDecimalTimeDelta(m_pThis->m_Hdr.get_Timestamp_ms() - m_pPrev->m_Hdr.get_Timestamp_ms()).m_sz); }
+        void OnData_Time_Rel() { m_json.push_back(m_This.MakeDecimalTimeDelta(get_Timestamp_ms_safe(m_pThis->m_Hdr) - get_Timestamp_ms_safe(m_pPrev->m_Hdr)).m_sz); }
 
         void OnName_Age_Abs() { m_json.push_back(MakeTableHdr("Age")); }
         void OnName_Age_Rel() { m_json.push_back(MakeTableHdr("d.Age")); }
-        void OnData_Age_Abs() { m_json.push_back(m_This.MakeDecimalTimeDelta(m_pThis->m_Hdr.get_Timestamp_ms() - m_This.get_TimeStampGenesis_ms()).m_sz); }
+        void OnData_Age_Abs() { m_json.push_back(m_This.MakeDecimalTimeDelta(get_Timestamp_ms_safe(m_pThis->m_Hdr) - m_This.get_TimeStampGenesis_ms()).m_sz); }
         void OnData_Age_Rel() { OnData_Time_Rel(); }
 
         void OnName_Difficulty_Abs() { m_json.push_back(MakeTableHdr("Chainwork")); }
@@ -3068,8 +3074,8 @@ private:
                 {"receive_asset_id", order.getSecondAssetId()},
                 {"receive_currency", order.getSecondAssetSname()},
                 {"receive_amount", std::to_string(wallet::PrintableAmount(order.getSecondAmount()))},
-                {"create_time", format_timestamp(wallet::kTimeStampFormat3x3, order.getCreation() * 1000, false)},
-                {"expire_time", format_timestamp(wallet::kTimeStampFormat3x3, order.getExpiration() * 1000, false)},
+                {"create_time", order.getCreation()},
+                {"expire_time", order.getExpiration()},
             });
         }
 

--- a/explorer/adapter.h
+++ b/explorer/adapter.h
@@ -79,6 +79,10 @@ struct IAdapter {
     virtual json get_swap_offers() = 0;
     virtual json get_swap_totals() = 0;
 #endif  // BEAM_ATOMIC_SWAP_SUPPORT
+#ifdef BEAM_ASSET_SWAP_SUPPORT
+    virtual json get_asset_swaps() = 0;
+    virtual json get_asset_swaps_totals() = 0;
+#endif  // BEAM_ASSET_SWAP_SUPPORT
     virtual json get_contracts() = 0;
     virtual json get_contract_details(const Blob& id, Height hMin, Height hMax, uint32_t nMaxTxs, bool bState, bool bOwnedAssets, bool bFundsLocked, bool bVerInfo) = 0;
     virtual json get_asset_details(uint32_t, Height hMin, Height hMax, uint32_t nMaxOps) = 0;

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -2814,7 +2814,24 @@
       text += '<p class="aboutDisclaimer">There are currently no offers for Atomic Swaps.</p>';
     } else {
       text += MakeCollapsibleBegin('Offers (' + jData.length + ')');
-      text += '<div class="divSwapOffers">' + Obj2Html(jData) + '</div>';
+      text += '<table class="dataTable" border="1" cellspacing="0"><thead><tr>'
+            + '<th><span class="th">Sends</span></th>'
+            + '<th><span class="th">For</span></th>'
+            + '<th><span class="th">Created</span></th>'
+            + '<th><span class="th">Expires</span></th>'
+            + '<th><span class="th">Order ID</span></th>'
+            + '</tr></thead>';
+      for (const o of jData) {
+        const beam = MakeAmountClr(o.beam_amount) + ' BEAM';
+        text += '<tr>'
+              + MakeCellRA(o.is_beam_side ? beam : o.swap_amount)
+              + MakeCellRA(o.is_beam_side ? o.swap_amount : beam)
+              + MakeCell(o.time_created)
+              + MakeCellRA(o.height_expired)
+              + MakeCell(o.txId)
+              + '</tr>';
+      }
+      text += '</table>';
       text += MakeCollapsibleEnd();
       text += MakeCollapsibleBegin('Totals');
       text += '<div id="divSwapTotals"><p>Loading...</p></div>';

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -2846,7 +2846,23 @@
       text += '<p class="aboutDisclaimer">There are currently no offers for Asset Swaps.</p>';
     } else {
       text += MakeCollapsibleBegin('Offers (' + jData.length + ')');
-      text += '<div class="divSwapOffers">' + Obj2Html(jData) + '</div>';
+      text += '<table class="dataTable" border="1" cellspacing="0"><thead><tr>'
+            + '<th><span class="th">Sends</span></th>'
+            + '<th><span class="th">For</span></th>'
+            + '<th><span class="th">Created</span></th>'
+            + '<th><span class="th">Expires</span></th>'
+            + '<th><span class="th">Order ID</span></th>'
+            + '</tr></thead>';
+      for (const o of jData) {
+        text += '<tr>'
+              + MakeCellRA(MakeAmountClr(o.send_amount) + ' ' + o.send_currency)
+              + MakeCellRA(MakeAmountClr(o.receive_amount) + ' ' + o.receive_currency)
+              + MakeCell(o.create_time)
+              + MakeCell(o.expire_time)
+              + MakeCell(o.id)
+              + '</tr>';
+      }
+      text += '</table>';
       text += MakeCollapsibleEnd();
       text += MakeCollapsibleBegin('Totals');
       text += '<div id="divAssetSwapTotals"><p>Loading...</p></div>';
@@ -2866,7 +2882,20 @@
 
   function DisplayAssetSwapTotals() { // Query node for Asset Swap totals and display them in existing 'div'
     const jData = JSON.parse(this.responseText);
-    let text = Obj2Html(jData);
+    let text = '<p class="aboutText">Total offers: ' + jData.total_offers_count + '</p>';
+    text += '<table class="dataTable" border="1" cellspacing="0"><thead><tr>'
+          + '<th><span class="th">Asset</span></th>'
+          + '<th><span class="th">Offered</span></th>'
+          + '<th><span class="th">Wanted</span></th>'
+          + '</tr></thead>';
+    for (const a of jData.assets) {
+      text += '<tr>'
+            + MakeCell(a.currency)
+            + MakeCellRA(MakeAmountClr(a.amount_offered))
+            + MakeCellRA(MakeAmountClr(a.amount_wanted))
+            + '</tr>';
+    }
+    text += '</table>';
     document.getElementById('divAssetSwapTotals').innerHTML = text;
   }
 

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -2882,8 +2882,7 @@
 
   function DisplayAssetSwapTotals() { // Query node for Asset Swap totals and display them in existing 'div'
     const jData = JSON.parse(this.responseText);
-    let text = '<p class="aboutText">Total offers: ' + jData.total_offers_count + '</p>';
-    text += '<table class="dataTable" border="1" cellspacing="0"><thead><tr>'
+    let text = '<table class="dataTable" border="1" cellspacing="0"><thead><tr>'
           + '<th><span class="th">Asset</span></th>'
           + '<th><span class="th">Offered</span></th>'
           + '<th><span class="th">Wanted</span></th>'

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -2855,8 +2855,8 @@
             + '</tr></thead>';
       for (const o of jData) {
         text += '<tr>'
-              + MakeCellRA(MakeAmountClr(o.send_amount) + ' ' + o.send_currency)
-              + MakeCellRA(MakeAmountClr(o.receive_amount) + ' ' + o.receive_currency)
+              + MakeCellRA(MakeAmountClr(o.send_amount) + ' ' + o.send_currency + ' (' + o.send_asset_id + ')')
+              + MakeCellRA(MakeAmountClr(o.receive_amount) + ' ' + o.receive_currency + ' (' + o.receive_asset_id + ')')
               + MakeCell(o.create_time)
               + MakeCell(o.expire_time)
               + MakeCell(o.id)
@@ -2889,7 +2889,7 @@
           + '</tr></thead>';
     for (const a of jData.assets) {
       text += '<tr>'
-            + MakeCell(a.currency)
+            + MakeCell(a.currency + ' (' + a.asset_id + ')')
             + MakeCellRA(MakeAmountClr(a.amount_offered))
             + MakeCellRA(MakeAmountClr(a.amount_wanted))
             + '</tr>';

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -2874,8 +2874,8 @@
         text += '<tr>'
               + MakeCellRA(MakeAmountClr(o.send_amount) + ' ' + o.send_currency + ' (' + o.send_asset_id + ')')
               + MakeCellRA(MakeAmountClr(o.receive_amount) + ' ' + o.receive_currency + ' (' + o.receive_asset_id + ')')
-              + MakeCell(o.create_time)
-              + MakeCell(o.expire_time)
+              + MakeCell(formatTimestamp(o.create_time, 'local'))
+              + MakeCell(formatTimestamp(o.expire_time, 'local'))
               + MakeCell(o.id)
               + '</tr>';
       }

--- a/explorer/htm/BeamExplorer.htm
+++ b/explorer/htm/BeamExplorer.htm
@@ -1901,6 +1901,8 @@
             <span class="menuSeparator"> | </span>
             <span class="menuItem"><a href="?network=$network&type=swap_offers" title="List of current Atomic Swap offers">Atomic Swaps</a></span>
             <span class="menuSeparator"> | </span>
+            <span class="menuItem"><a href="?network=$network&type=asset_swaps" title="List of current Asset Swap offers">Asset Swaps</a></span>
+            <span class="menuSeparator"> | </span>
             <span class="menuItem"><a href="?network=$network&type=historical" title="List of special historical blocks">Historical blocks</a></span>
           </div>
           <div id="SearchArea">
@@ -2836,6 +2838,38 @@
     document.getElementById('divSwapTotals').innerHTML = text;
   }
 
+  function DisplayAssetSwaps() {
+    const jData = JSON.parse(this.responseText);
+
+    let text = '<h2 class="title">Asset Swaps</h2>';
+    if (jData.length === 0) {
+      text += '<p class="aboutDisclaimer">There are currently no offers for Asset Swaps.</p>';
+    } else {
+      text += MakeCollapsibleBegin('Offers (' + jData.length + ')');
+      text += '<div class="divSwapOffers">' + Obj2Html(jData) + '</div>';
+      text += MakeCollapsibleEnd();
+      text += MakeCollapsibleBegin('Totals');
+      text += '<div id="divAssetSwapTotals"><p>Loading...</p></div>';
+      text += MakeCollapsibleEnd();
+    }
+
+    SetContent(text);
+
+    // Get Asset Swap totals (new node request)
+    if (jData.length !== 0) {
+      const xmlhttp = new XMLHttpRequest();
+      xmlhttp.onload = DisplayAssetSwapTotals;
+      xmlhttp.open('GET', urlPrefix + 'asset_swaps_totals');
+      xmlhttp.send();
+    }
+  }
+
+  function DisplayAssetSwapTotals() { // Query node for Asset Swap totals and display them in existing 'div'
+    const jData = JSON.parse(this.responseText);
+    let text = Obj2Html(jData);
+    document.getElementById('divAssetSwapTotals').innerHTML = text;
+  }
+
   function DisplayHistoricalBlocks() {
     let text = `<h2 class="title">Special historical blocks in Beam's mainnet</h2>`;
     text += `<table class="dataTable tableHistoricalBlocks" border="1" cellspacing="0">
@@ -3276,6 +3310,10 @@
     } else if (g_type == 'swap_offers') { // Arguments for 'swap_offers': (none)
       xmlhttp.onload = DisplayAtomicSwaps;
     // Remark: The query for 'swap_totals' is made from within the 'DisplayAtomicSwaps' function.
+
+    } else if (g_type == 'asset_swaps') { // Arguments for 'asset_swaps': (none)
+      xmlhttp.onload = DisplayAssetSwaps;
+    // Remark: The query for 'asset_swaps_totals' is made from within the 'DisplayAssetSwaps' function.
 
     } else {
       g_type = 'status'; // Arguments for 'status': (none)

--- a/explorer/server.cpp
+++ b/explorer/server.cpp
@@ -805,6 +805,16 @@ OnRequest(swap_totals)
     return _backend.get_swap_totals();
 }
 
+OnRequest(asset_swaps)
+{
+    return _backend.get_asset_swaps();
+}
+
+OnRequest(asset_swaps_totals)
+{
+    return _backend.get_asset_swaps_totals();
+}
+
 OnRequest(contracts)
 {
     return _backend.get_contracts();

--- a/explorer/server.h
+++ b/explorer/server.h
@@ -29,6 +29,8 @@
     macro(peers) \
     macro(swap_offers) \
     macro(swap_totals) \
+    macro(asset_swaps) \
+    macro(asset_swaps_totals) \
     macro(contracts) \
     macro(contract) \
     macro(asset) \


### PR DESCRIPTION
## Summary

Implements #2053. The explorer node already exposes atomic-swap offers via `swap_offers` / `swap_totals`, but had no equivalent for **Asset Swaps (DEX)**. This adds two read-only endpoints:

- **`/asset_swaps`** — live asset-swap (DEX) offers
- **`/asset_swaps_totals`** — per-asset aggregate totals + offer count

The node already receives this data over SBBS broadcast, so no wallet / wallet-API is required.

Both endpoints are documented in the [Beam Node Explorer API reference](https://github.com/BeamMW/docs-gitbook/blob/doc-overhaul/core-tech/api/Beam-Node-Explorer-API.md).

## How it works

The adapter builds a read-only `DexBoard` over the broadcast router and wallet DB it already creates for the atomic-swap board. It subscribes to the DEX offers broadcast channel and accumulates offers (foreign offers are kept with `isMine=false`, not rejected). A no-op `IRawCommGateway` is passed because the explorer only **lists** offers — it never accepts or processes trades.

Plumbing mirrors the existing `swap_offers` / `swap_totals` path exactly: an entry in the `ExplorerNodeDirs` macro, `OnRequest` handlers, and backend methods. The new code is gated by `BEAM_ASSET_SWAP_SUPPORT`, matching how atomic swaps are gated by `BEAM_ATOMIC_SWAP_SUPPORT` (required, since the wallet DB's DEX methods are themselves behind that flag).

### `/asset_swaps`

Reported in **maker terms** (`send_*` = what the maker offers, `receive_*` = what the maker wants), using the absolute first/second sides rather than `DexOrder`'s `isMine`-relative `send/receive` helpers (which are perspective-dependent and meaningless on a neutral node). Amounts are formatted with `PrintableAmount`, timestamps returned as raw unix seconds (formatted client-side, as on the block-headers page).

```json
{
  "id": "<order-uuid>",
  "send_asset_id": 0, "send_currency": "BEAM", "send_amount": "4,862.63068319",
  "receive_asset_id": 7, "receive_currency": "USDT", "receive_amount": "500",
  "create_time": 1781784005, "expire_time": 1781785805
}
```

### `/asset_swaps_totals`

```json
{
  "total_offers_count": 12,
  "assets": [
    { "asset_id": 0, "currency": "BEAM", "amount_offered": "5,000", "amount_wanted": "0" },
    { "asset_id": 7, "currency": "USDT", "amount_offered": "0", "amount_wanted": "2,500" }
  ]
}
```

## Bugfixes

Fixes the explorer needed alongside the feature:

- **PoW block timestamps rendered as `1970-01-01`.** `get_Timestamp_s()` and the hdrs **Age** / **block-duration** deltas read `SystemState::get_Timestamp_ms()`, which carries a value only for PBFT/PoS consensus — on a PoW chain it reinterprets the PoW solution as PBFT header data and returns 0, so every block / header / status timestamp (and the Age and `d.Time` columns) collapsed to the epoch. Regression from [`221cc7da2`](https://github.com/BeamMW/beam/commit/221cc7da2159e28c04e97849640fdfcc619d32d4) (*"explorer: showing time in ms where applicable (for PoS networks)"*). Fixed by choosing the source from the chain's consensus type (`Rules::m_Consensus`) via a single `get_Timestamp_ms_safe()` helper used at every affected site: the ms timestamp for `Pbft`, the seconds field `m_TimeStamp` for `PoW` / `FakePoW`.

- **`-Wdeprecated-literal-operator` build break.** Recent clang flags the whitespace-before-suffix user-defined-literal spelling in the bundled `3rdparty/nlohmann/json.hpp`; with the project's unconditional `-Werror` this breaks the build of any target that includes it (e.g. `explorer-node`). Added `-Wno-deprecated-literal-operator` to the AppleClang flag block, next to the existing `-Wno-enum-constexpr-conversion` handling.

