### PR TITLE
explorer: restore treasury view by treating explicit height=0 distinctly from a missing height

### DIFF
--- a/explorer/adapter.cpp
+++ b/explorer/adapter.cpp
@@ -2891,6 +2891,15 @@ private:
         if (h)
             return extract_block_from_row(sid, s, h);
 
+        // Edge-case guard only (fresh node with no blocks, or prune-navigation
+        // via adj<0 that falls back to h=0). The primary way to view the
+        // treasury is an explicit height=0 request, dispatched in
+        // Server::on_request_block -> get_treasury().
+        return get_treasury();
+    }
+
+    json get_treasury() override
+    {
         json out;
         get_treasury(out);
         return out;

--- a/explorer/adapter.h
+++ b/explorer/adapter.h
@@ -70,6 +70,7 @@ struct IAdapter {
     /// Returns body for /status request
     virtual json get_status() = 0;
     virtual json get_block(Height height, int adj) = 0;
+    virtual json get_treasury() = 0;
     virtual json get_block_by_kernel(const Blob& key) = 0;
     virtual json get_blocks(Height startHeight, uint64_t n) = 0;
     virtual json get_hdrs(Height hMax, uint64_t nMax, uint64_t dn, const TotalsCol* pCols, uint32_t nCols) = 0;

--- a/explorer/server.cpp
+++ b/explorer/server.cpp
@@ -700,7 +700,13 @@ OnRequest(block)
     if (get_UrlHexArg(_currentUrl, "kernel", hv))
         return _backend.get_block_by_kernel(hv);
 
+    // An explicit height=0 requests the treasury (pseudo-block at height 0).
+    // A missing height means "latest block" (see get_block).
+    auto itHeight = _currentUrl.args.find("height");
     auto height = _currentUrl.get_int_arg("height", 0);
+    if (_currentUrl.args.end() != itHeight && !height)
+        return _backend.get_treasury();
+
     auto adj = _currentUrl.get_int_arg("adj", 0);
     return _backend.get_block(height, static_cast<int>(adj));
 }


### PR DESCRIPTION
## Summary

The treasury view (`?network=mainnet&type=treasury`, which requests `block?height=0`) was silently broken: it displayed the current tip block instead of the treasury UTXO groups.

The cause is #1990 ("display current block instead of treasury when calling block with no arguments"). That change implemented "no arguments" as `if (height) { … } else { return tip }`, which treats an **absent** `height` and an **explicit `height=0`** identically. As a result, the only route that reaches `get_treasury()` on a synced full node was removed, and the frontend's treasury link — which deliberately sends `height=0` — started rendering the latest block.

The `get_treasury()` fallback in `get_block()` was noted at the time as "kept for safety … in practice never reached under normal operation." That was accurate, but it was the symptom: the code path had a real caller (`type=treasury` → `height=0`), so making it unreachable broke a feature rather than pruning dead code.

## Root cause

"No argument" and "`height=0`" were never actually distinct in this code — the ambiguity is structural, in two layers:

1. **`Height` is `uint64_t` and 0 is a valid height** (the treasury pseudo-block), yet **0 is also the "unspecified" sentinel.** The value meaning "give me the zero-height block" is the same value meaning "caller gave nothing."
2. **`get_int_arg("height", 0)` erases the distinction that still existed in the raw request.** The `args` map knows whether `height` was in the URL, but `get_int_arg` returns the default `0` for an absent arg — the identical `int64_t` produced by an explicit `&height=0`. From that call onward the two are physically indistinguishable, and `get_block`'s `if (height)` reads both as "no height."

So it wasn't a deliberate decision to equate them — the code simply never carried a "was it provided?" bit, and reused `0` for two meanings. That's why the fix has to reach *underneath* `get_int_arg`.

## Fix

Distinguish the two cases at the router level, in `Server::on_request_block`, by checking the raw `args` map (the one layer that still preserves presence-vs-absence):

- **`height` absent** → latest block (preserves #1990's intent; bare `block` still shows the tip)
- **explicit `height=0`** → treasury (restores the existing frontend link, no HTML change)

A `get_treasury()` method is added to the `IAdapter` interface so the router can dispatch to it directly, and the existing fallback inside `get_block()` is annotated as a genuine edge-case guard (fresh node with no blocks, or prune-navigation via `adj<0`).

## Changes

- `explorer/server.cpp` — in `on_request_block`, route an explicit `height=0` to `get_treasury()`; a missing `height` still falls through to `get_block()`.
- `explorer/adapter.h` — add `virtual json get_treasury() = 0;` to `IAdapter`.
- `explorer/adapter.cpp` — expose `get_treasury()` (wraps the existing private `get_treasury(json&)`); document the in-`get_block` fallback as an edge-case guard.

## Behavior

| Request | Before | After |
|---|---|---|
| `block` (no height) | tip | tip |
| `block?height=0` | tip ❌ | treasury ✅ |
| `block?height=N` | block N | block N |
| `?type=treasury` (frontend) | tip block ❌ | treasury UTXO groups ✅ |

No frontend change required. Compiles clean (`explorer` target).

## Testing

Tested the above behaviors, all good.
