### PR TITLE
explorer: fix stale per-element state and ignored adj in /blocks

### DIFF
--- a/explorer/adapter.cpp
+++ b/explorer/adapter.cpp
@@ -2838,6 +2838,49 @@ private:
         return json{ { "found", false}, {"height", h } };
     }
 
+    // Resolves the block for the given height and adj direction. false if there's none (vacant height, no adj)
+    // h is the resolved height, 0 means treasury
+    bool ResolveBlock(NodeDB::StateID& sid, Block::SystemState::Full& s, Height& h, Height height, int adj)
+    {
+        assert(height);
+
+        if (FindBlockByHeight(sid, s, height))
+        {
+            h = s.get_Height();
+            assert(h >= height);
+        }
+        else
+        {
+            assert(height > _nodeBackend.m_Cursor.m_hh.m_Height); // requested above current tip
+
+            sid = _nodeBackend.m_Cursor.get_Sid();
+            s = _nodeBackend.m_Cursor.m_Full;
+            h = _nodeBackend.m_Cursor.m_hh.m_Height;
+        }
+
+        if (h != height)
+        {
+            if (!adj)
+                return false;
+
+            if ((h > height) && (adj < 0))
+            {
+                if (_nodeBackend.get_DB().get_Prev(sid))
+                {
+                    _nodeBackend.get_DB().get_State(sid.m_Row, s);
+                    h = s.get_Height();
+                    assert(h < height);
+                }
+                else
+                    h = 0; // fall back to treasury
+            }
+
+            // ignore other cases
+        }
+
+        return true;
+    }
+
     json get_block(Height height, int adj) override
     {
         NodeDB::StateID sid;
@@ -2846,39 +2889,8 @@ private:
 
         if (height)
         {
-            if (FindBlockByHeight(sid, s, height))
-            {
-                h = s.get_Height();
-                assert(h >= height);
-            }
-            else
-            {
-                assert(height > _nodeBackend.m_Cursor.m_hh.m_Height); // requested above current tip
-
-                sid = _nodeBackend.m_Cursor.get_Sid();
-                s = _nodeBackend.m_Cursor.m_Full;
-                h = _nodeBackend.m_Cursor.m_hh.m_Height;
-            }
-
-            if (h != height)
-            {
-                if (!adj)
-                    return get_block_not_found(height);
-
-                if ((h > height) && (adj < 0))
-                {
-                    if (_nodeBackend.get_DB().get_Prev(sid))
-                    {
-                        _nodeBackend.get_DB().get_State(sid.m_Row, s);
-                        h = s.get_Height();
-                        assert(h < height);
-                    }
-                    else
-                        h = 0; // fall back to treasury
-                }
-
-                // ignore other cases
-            }
+            if (!ResolveBlock(sid, s, h, height, adj))
+                return get_block_not_found(height);
         }
         else
         {
@@ -2919,7 +2931,7 @@ private:
         return get_block_not_found(h);
     }
 
-    json get_blocks(Height startHeight, uint64_t n) override {
+    json get_blocks(Height startHeight, uint64_t n, int adj) override {
 
         json result = json::array();
 
@@ -2929,25 +2941,45 @@ private:
 
         NodeDB::StateID sid;
         Block::SystemState::Full s;
+        Height h = startHeight;
 
         Height endHeight = startHeight + n - 1; // correct only for PoW
         _exchangeRateProvider->preloadRates(startHeight, endHeight);
 
-        if (FindBlockByHeight(sid, s, startHeight))
+        // adj applies to the 1st block only, the rest follow upwards
+        if (!ResolveBlock(sid, s, h, startHeight, adj))
         {
-            while (true)
+            result.push_back(get_block_not_found(startHeight));
+            return result;
+        }
+
+        if (!h)
+        {
+            // treasury, nothing to continue from
+            result.push_back(get_treasury());
+            return result;
+        }
+
+        while (true)
+        {
+            result.push_back(extract_block_from_row(sid, s, h));
+            if (!--n)
+                break;
+
+            if (sid.m_Number.v >= _nodeBackend.m_Cursor.m_Full.m_Number.v)
             {
-                result.push_back(extract_block_from_row(sid, s, s.get_Height()));
-                if (!--n)
-                    break;
-
-                if (sid.m_Number.v >= _nodeBackend.m_Cursor.m_Full.m_Number.v)
-                    break;
-
-                sid.m_Number.v++;
-                sid.m_Row = _nodeBackend.FindActiveAtStrict(sid.m_Number);
+                // past the tip, report the rest as missing
+                while (n--)
+                    result.push_back(get_block_not_found(++h)); // correct only for PoW
+                break;
             }
 
+            sid.m_Number.v++;
+            sid.m_Row = _nodeBackend.FindActiveAtStrict(sid.m_Number);
+
+            _nodeBackend.get_DB().get_State(sid.m_Row, s);
+
+            h = s.get_Height();
         }
 
         return result;

--- a/explorer/adapter.h
+++ b/explorer/adapter.h
@@ -72,7 +72,7 @@ struct IAdapter {
     virtual json get_block(Height height, int adj) = 0;
     virtual json get_treasury() = 0;
     virtual json get_block_by_kernel(const Blob& key) = 0;
-    virtual json get_blocks(Height startHeight, uint64_t n) = 0;
+    virtual json get_blocks(Height startHeight, uint64_t n, int adj) = 0;
     virtual json get_hdrs(Height hMax, uint64_t nMax, uint64_t dn, const TotalsCol* pCols, uint32_t nCols) = 0;
     virtual json get_peers() = 0;
 

--- a/explorer/server.cpp
+++ b/explorer/server.cpp
@@ -718,7 +718,8 @@ OnRequest(blocks)
     if (start <= 0 || n < 0)
         Exc::Fail("#3.1");
 
-    return _backend.get_blocks(start, n);
+    auto adj = _currentUrl.get_int_arg("adj", 0);
+    return _backend.get_blocks(start, n, static_cast<int>(adj));
 }
 
 OnRequest(hdrs)


### PR DESCRIPTION
## Summary

Two bugs in the explorer's `/blocks` (plural) endpoint, reported by @dbadol as #2077 and #2078. Both live in `Adapter::get_blocks`, so they're fixed together.

## #2077 — every element carries the first block's header

Regression from ba181a9d6, which replaced the old per-row `get_block_impl()` walk with a `StateID`/`m_Number` loop. The loop advances the row but never reloads the state for it, so every element after the first is rendered against the *first* block's `Block::SystemState::Full`:

```cpp
sid.m_Number.v++;
sid.m_Row = _nodeBackend.FindActiveAtStrict(sid.m_Number);   // `s` left stale
```

Because the body is read from `sid.m_Row` (correct) while the header and context come from `s` (stale), the damage is wider than the report: on top of `h` and `info`, the `totals` table (`Chainwork`, `Current Emission`, `Current Circulation`, `Size Compressed`, `Size Archive`) and `outputs[].Maturity` are all wrong. Verified against mainnet — for block 27730 in a `height=27729&n=4` series, emission reads `2,218,320` instead of `2,218,400` and the coinbase maturity `27969` instead of `27970`. `inputs` and `kernels` were the only correct sections.

Fixed by reloading the state after each step.

## #2078 — `adj` is ignored

`adj` simply never reached the backend: `on_request_blocks` parsed only `height` and `n`, and `get_blocks` had no `adj` parameter. What looked like "defaults to `adj=1`" was `FindBlockByHeight` → `FindAtivePastHeight` snapping to the next active height unconditionally, which also meant `/blocks` had no not-found path at all.

Fixed per the three points in the issue:

1. `adj` is parsed and passed through, and applies to the first block of the series only; the rest always follow upwards.
2. A vacant `height` with no `adj` returns `{"found":false,"height":N}`, matching `/block`.
3. Once the walk passes the tip, the remaining elements are filled with the same not-found objects, so the array always has `n` entries.

To keep `/block` and `/blocks` from drifting apart again, the first-block resolution is now shared: `get_block`'s logic is factored into `ResolveBlock(sid, s, h, height, adj)` and both endpoints call it.

## Changes

- `explorer/server.cpp` — `on_request_blocks` parses `adj` and passes it on.
- `explorer/adapter.h` — `get_blocks(Height, uint64_t, int adj)`.
- `explorer/adapter.cpp` — new `ResolveBlock` helper shared with `get_block`; `get_blocks` refreshes the state per element, honors `adj` for the first block, and emits not-found placeholders.

## Behavior

| Request (dappnet2, PoS with gaps) | Before | After |
|---|---|---|
| `blocks?height=2743&n=4` | 4 blocks, all with 2743's header | 4 blocks, own headers |
| `blocks?height=2742&n=4` (vacant) | series from 2743 | `[{"found":false,"height":2742}]` |
| `blocks?height=2742&n=4&adj=1` | series from 2743 | series from 2743 |
| `blocks?height=2744&n=4&adj=-1` | series from 2795 ❌ | series from 2743 ✅ |
| series running past the tip | short array, empty blocks | `n` entries, tail is `found:false` |

Two judgement calls worth a look, since the spec is ambiguous for PoS chains:

- Point 2 returns a one-element array rather than a bare object, to keep `/blocks` type-stable for clients. Easy to change if the bare object is preferred.
- The placeholder heights past the tip are consecutive (`tip+1`, `tip+2`, …), which only carries meaning on PoW. On a PoS chain with gaps they should be read as "no block here", not as a height prediction.

Closes #2077
Closes #2078

